### PR TITLE
add writer registry to dedup btc address get / set

### DIFF
--- a/contracts/Option.sol
+++ b/contracts/Option.sol
@@ -7,6 +7,7 @@ import "@nomiclabs/buidler/console.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IWriterRegistry } from "./interface/IWriterRegistry.sol";
 import { Obligation } from "./Obligation.sol";
 import { IObligation } from "./interface/IObligation.sol";
 import { IOption } from "./interface/IOption.sol";
@@ -146,7 +147,7 @@ contract Option is IOption, IERC20, European, Ownable {
     ) external override canExercise {
         address buyer = msg.sender;
 
-        (bytes20 btcHash,) = IObligation(obligation).getBtcAddress(seller);
+        (bytes20 btcHash,) = IWriterRegistry(obligation).getBtcAddress(seller);
 
         // verify & validate tx, use default confirmations
         uint output = IReferee(referee)

--- a/contracts/OptionPairFactory.sol
+++ b/contracts/OptionPairFactory.sol
@@ -7,27 +7,19 @@ import "@nomiclabs/buidler/console.sol";
 import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 import { IERC20 } from "@uniswap/v2-periphery/contracts/interfaces/IERC20.sol";
-import { IUniswapV2Pair } from "@uniswap/v2-core/contracts/interfaces/IUniswapV2Pair.sol";
-import { IUniswapV2Factory } from "./lib/IUniswapV2Factory.sol";
 import { IReferee } from "./interface/IReferee.sol";
-import { Bitcoin } from "./types/Bitcoin.sol";
 import { Option } from "./Option.sol";
 import { IOption } from "./interface/IOption.sol";
 import { Obligation } from "./Obligation.sol";
 import { IObligation } from "./interface/IObligation.sol";
 import { IOptionPairFactory } from "./interface/IOptionPairFactory.sol";
 import { Treasury } from "./Treasury.sol";
-import { ITreasury } from "./interface/ITreasury.sol";
 
 /// @title Parent Factory
 /// @author Interlay
 /// @notice Tracks and manages ERC20 Option pairs.
 contract OptionPairFactory is IOptionPairFactory {
     using SafeMath for uint256;
-
-    string constant ERR_INVALID_OPTION = "Option does not exist";
-    string constant ERR_ZERO_AMOUNT = "Requires non-zero amount";
-    string constant ERR_NO_BTC_ADDRESS = "Insurer lacks BTC address";
 
     /// @notice Emitted whenever this factory creates a new option pair.
     event Create(address indexed option, address indexed obligation, uint256 expiryTime, uint256 windowSize, uint256 strikePrice);
@@ -36,35 +28,6 @@ contract OptionPairFactory is IOptionPairFactory {
     mapping(address => address) public getTreasury;
     mapping(address => address) public getCollateral;
     address[] public options;
-
-    mapping (address => Bitcoin.Address) internal _btcAddresses;
-
-    /**
-    * @notice Sets the preferred payout address for the caller.
-    *
-    * The script format is defined by the `Bitcoin.Script` enum which describes
-    * the expected output format (P2SH, P2PKH, P2WPKH).
-    *
-    * @param btcHash Address hash
-    * @param format Payment format
-    **/
-    function setBtcAddress(bytes20 btcHash, Bitcoin.Script format) external override {
-        require(
-            btcHash != 0,
-            ERR_NO_BTC_ADDRESS
-        );
-        _btcAddresses[msg.sender].btcHash = btcHash;
-        _btcAddresses[msg.sender].format = format;
-    }
-
-    /**
-    * @notice Get the preferred BTC address for the caller.
-    * @return btcHash Address hash
-    * @return format Payment format
-    **/
-    function getBtcAddress() external override view returns (bytes20 btcHash, Bitcoin.Script format) {
-        return (_btcAddresses[msg.sender].btcHash, _btcAddresses[msg.sender].format);
-    }
 
     function _createOption(
         uint8 decimals,

--- a/contracts/WriterRegistry.sol
+++ b/contracts/WriterRegistry.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.6.0;
+
+import { IWriterRegistry } from "./interface/IWriterRegistry.sol";
+import { Bitcoin } from "./types/Bitcoin.sol";
+
+contract WriterRegistry is IWriterRegistry {
+
+    string constant ERR_NO_BTC_HASH = "Cannot set empty BTC address";
+
+    mapping (address => Bitcoin.Address) internal _btcAddresses;
+
+    function _setBtcAddress(address account, bytes20 btcHash, Bitcoin.Script format) internal {
+        require(
+            btcHash != 0,
+            ERR_NO_BTC_HASH
+        );
+        _btcAddresses[account].btcHash = btcHash;
+        _btcAddresses[account].format = format;
+    }
+
+    /**
+    * @notice Sets the payout address for the caller.
+    *
+    * The script format is defined by the `Bitcoin.Script` enum which describes
+    * the expected output format (P2SH, P2PKH, P2WPKH).
+    *
+    * @param btcHash Address hash
+    * @param format Payment format
+    **/
+    function setBtcAddress(bytes20 btcHash, Bitcoin.Script format) external virtual override {
+        _setBtcAddress(msg.sender, btcHash, format);
+    }
+
+    /**
+    * @notice Get the configured BTC address for an account.
+    * @param account Minter address
+    * @return btcHash Address hash
+    * @return format Expected payment format
+    **/
+    function getBtcAddress(address account) external override view returns (bytes20 btcHash, Bitcoin.Script format) {
+        return (_btcAddresses[account].btcHash, _btcAddresses[account].format);
+    }
+
+}

--- a/contracts/interface/IObligation.sol
+++ b/contracts/interface/IObligation.sol
@@ -26,8 +26,4 @@ interface IObligation {
 
     function withdraw(uint amount, address pool) external;
 
-    function setBtcAddress(bytes20 btcHash, Bitcoin.Script format) external;
-
-    function getBtcAddress(address account) external view returns (bytes20 btcHash, Bitcoin.Script format);
-
 }

--- a/contracts/interface/IOptionPairFactory.sol
+++ b/contracts/interface/IOptionPairFactory.sol
@@ -16,8 +16,4 @@ interface IOptionPairFactory {
 
     function allOptions() external view returns (address[] memory);
 
-    function setBtcAddress(bytes20 btcHash, Bitcoin.Script format) external;
-
-    function getBtcAddress() external view returns (bytes20 btcHash, Bitcoin.Script format);
-
 }

--- a/contracts/interface/IWriterRegistry.sol
+++ b/contracts/interface/IWriterRegistry.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.6.0;
+
+import { Bitcoin } from "../types/Bitcoin.sol";
+
+interface IWriterRegistry {
+
+    function setBtcAddress(bytes20 btcHash, Bitcoin.Script format) external;
+
+    function getBtcAddress(address account) external view returns (bytes20 btcHash, Bitcoin.Script format);
+
+}

--- a/lib/addresses.ts
+++ b/lib/addresses.ts
@@ -8,6 +8,7 @@ export interface Addresses {
     optionLib: string;
     relay: string;
     referee: string;
+    writerRegistry: string;
 }
 
 type Networks = "buidler" | "ganache";
@@ -19,6 +20,7 @@ export const Deployments: Record<Networks, Addresses> = {
         optionLib: "0xf784709d2317D872237C4bC22f867d1BAe2913AB",
         relay: "0x3619DbE27d7c1e7E91aA738697Ae7Bc5FC3eACA5",
         referee: "0x038B86d9d8FAFdd0a02ebd1A476432877b0107C8",
+        writerRegistry: "0x1A1FEe7EeD918BD762173e4dc5EfDB8a78C924A8",
     },
     ganache: {
         collateral: "0x151eA753f0aF1634B90e1658054C247eFF1C2464",
@@ -26,6 +28,7 @@ export const Deployments: Record<Networks, Addresses> = {
         optionLib: "0x71dBe5Bd681c86d12211629EB19fE836149c6bf8",
         relay: "0xA7102d753442D827A853FeFE3DD88E182aea622D",
         referee: "0x5429c8fafa53b09386E41F07CbA2479C170faf0b",
+        writerRegistry: "0x5Ee87DE59a4701B3d073be6244cdf7ddE32c8D49",
     }
 }
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -20,22 +20,20 @@ export const ErrorCode = {
 
     // Obligation
     ERR_INVALID_OUTPUT_AMOUNT: "Invalid output amount",
-    ERR_NO_BTC_ADDRESS: "Insurer lacks BTC address",
+    ERR_NO_BTC_ADDRESS: "Account lacks BTC address",
     ERR_INSUFFICIENT_OBLIGATIONS: "Seller has insufficient obligations",
     ERR_INVALID_REQUEST: "Cannot exercise without an amount",
     ERR_SUB_WITHDRAW_BALANCE: "Insufficient pool balance",
     ERR_SUB_WITHDRAW_AVAILABLE: "Insufficient available",
     ERR_ZERO_STRIKE_PRICE: "Requires non-zero strike price",
 
-    // OptionPairFactory
-    ERR_INVALID_OPTION: "Option does not exist",
-    ERR_ZERO_AMOUNT: "Requires non-zero amount",
-    // ERR_NO_BTC_ADDRESS: "Insurer lacks BTC address",
-
     // Treasury
     ERR_INSUFFICIENT_DEPOSIT: "Insufficient deposit amount",
     ERR_INSUFFICIENT_LOCKED: "Insufficient collateral locked",
     ERR_INSUFFICIENT_UNLOCKED: "Insufficient collateral unlocked",
+
+    // WriterRegistry
+    ERR_NO_BTC_HASH: "Cannot set empty BTC address",
 
     // BTCReferee
     ERR_INVALID_OUT_HASH: "Invalid output hash",

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -8,6 +8,7 @@ import { deployUniswapFactory } from "../lib/uniswap";
 import { MockRelayFactory } from "../typechain/MockRelayFactory";
 import { constants } from "ethers";
 import { newBigNum } from "../lib/conversion";
+import { WriterRegistryFactory } from "../typechain";
 
 // ROPSTEN
 
@@ -29,6 +30,7 @@ async function main() {
 	const optionLib = await deploy2(signers[0], OptionLibFactory, uniswapFactory.address, constants.AddressZero);
 	const relay = await deploy0(signers[0], MockRelayFactory);
 	const referee = await deploy1(signers[0], BtcRefereeFactory, relay.address);
+	const writerRegistry = await deploy0(signers[0], WriterRegistryFactory);
 
 	console.log("MockCollateral:", collateral.address);
 	console.log("OptionPairFactory:", optionFactory.address);
@@ -36,6 +38,7 @@ async function main() {
 	console.log("UniswapFactory:", uniswapFactory.address);
 	console.log("MockRelay:", relay.address);
 	console.log("BTCReferee:", referee.address);
+	console.log("WriterRegistry:", writerRegistry.address);
 
 	var date = new Date();
 	let current_time = Math.round(date.getTime() / 1000);

--- a/scripts/testdata.ts
+++ b/scripts/testdata.ts
@@ -14,7 +14,7 @@ import { BigNumberish, BigNumber } from "ethers";
 import { MockCollateral } from "../typechain/MockCollateral";
 import { BtcReferee } from "../typechain/BtcReferee";
 import { OptionLib } from "../typechain/OptionLib";
-import { BtcRefereeFactory, MockRelayFactory } from "../typechain";
+import { BtcRefereeFactory, MockRelayFactory, WriterRegistryFactory } from "../typechain";
 
 const keyPair = bitcoin.ECPair.makeRandom();
 const payment = bitcoin.payments.p2pkh({pubkey: keyPair.publicKey, network: bitcoin.networks.testnet});
@@ -77,6 +77,7 @@ async function main() {
 	const optionLib = await deploy2(signers[0], OptionLibFactory, uniswapFactory.address, constants.AddressZero);
 	const relay = await deploy0(signers[0], MockRelayFactory);
 	const referee = await deploy1(signers[0], BtcRefereeFactory, relay.address);
+	const writerRegistry = await deploy0(signers[0], WriterRegistryFactory);
 
 	console.log("MockCollateral:", collateral.address);
 	console.log("OptionPairFactory:", optionFactory.address);
@@ -84,6 +85,7 @@ async function main() {
 	console.log("UniswapFactory:", uniswapFactory.address);
 	console.log("MockRelay:", relay.address);
 	console.log("BTCReferee:", referee.address);
+	console.log("WriterRegistry:", writerRegistry.address);
 
     // get collateral for everyone
 	await reconnect(collateral, MockCollateralFactory, alice).mint(aliceAddress, newBigNum(100_000, 18));

--- a/test/contracts/obligation.test.ts
+++ b/test/contracts/obligation.test.ts
@@ -57,7 +57,7 @@ describe("Obligation.sol", () => {
 
   it("should fail to set an empty btc address", async () => {
     const result = obligation.setBtcAddress(constants.AddressZero, Script.p2sh);
-    await expect(result).to.be.revertedWith(ErrorCode.ERR_NO_BTC_ADDRESS);
+    await expect(result).to.be.revertedWith(ErrorCode.ERR_NO_BTC_HASH);
   });
 
   it("should set a btc address", async () => {
@@ -69,7 +69,7 @@ describe("Obligation.sol", () => {
 
   it("should fail to mint obligations with no btc address", async () => {
     const result = obligation.mint(aliceAddress, 1000, constants.AddressZero, Script.p2sh);
-    await expect(result).to.be.revertedWith(ErrorCode.ERR_NO_BTC_ADDRESS);
+    await expect(result).to.be.revertedWith(ErrorCode.ERR_NO_BTC_HASH);
   });
 
   it("should mint obligations with btc address", async () => {
@@ -171,6 +171,13 @@ describe("Obligation.sol", () => {
       expect(obligationBalance).to.eq(constants.Zero);
     });
   });
+
+  it("should not set btc address after expiry", async () => {
+    return evmSnapFastForward(2000, async () => {
+      const result = obligation.setBtcAddress(btcHash, Script.p2pkh);
+      await expect(result).to.be.revertedWith(ErrorCode.ERR_EXPIRED);
+    });
+  }); 
 
   it("should sell obligations and withdraw", async () => {
     await treasury.mock.lock.returns();

--- a/test/contracts/writer-registry.test.ts
+++ b/test/contracts/writer-registry.test.ts
@@ -1,0 +1,42 @@
+import chai from "chai";
+import { ethers } from "@nomiclabs/buidler";
+import { Signer, BigNumber, constants } from "ethers";
+import { deploy0 } from "../../lib/contracts";
+import { WriterRegistry } from "../../typechain/WriterRegistry";
+import { WriterRegistryFactory } from "../../typechain";
+import { Script, ErrorCode } from "../../lib/constants";
+import * as bitcoin from 'bitcoinjs-lib';
+
+const { expect } = chai;
+
+describe("WriterRegistry.sol", () => {
+  let alice: Signer;
+  let aliceAddress: string;
+  let registry: WriterRegistry;
+
+  it("should deploy writer registry", async () => {
+    [alice] = await ethers.getSigners();
+    aliceAddress = await alice.getAddress();
+    registry = await deploy0(alice, WriterRegistryFactory);
+  });
+
+  it("should fail to set an empty address", async () => {
+    const result = registry.setBtcAddress(constants.AddressZero, Script.p2sh);
+    await expect(result).to.be.revertedWith(ErrorCode.ERR_NO_BTC_HASH);
+  });
+
+  it("should set an address", async () => {
+    const pair = bitcoin.ECPair.makeRandom();
+    const payment = bitcoin.payments.p2pkh({pubkey: pair.publicKey});
+    const btcAddress = payment.address!;
+    const btcHash = payment.hash!.toString('hex');
+    await registry.setBtcAddress(`0x${btcHash}`, Script.p2pkh);
+    const result = await registry.getBtcAddress(aliceAddress);
+    expect(result.format).to.eq(Script.p2pkh);
+    expect(result.btcHash).to.eq(`0x${btcHash}`);
+    const output = bitcoin.payments.p2pkh({
+      hash: Buffer.from(result.btcHash.substr(2), 'hex'),
+    });
+    expect(output.address!).to.eq(btcAddress);
+  });
+});


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Adds a new `WriterRegistry.sol` which can be deployed separately (to track 'preferred' BTC addresses) or inherited by `Obligation.sol` (to manage payout addresses).