### PR TITLE
balanceObl() -> obligations(), add available balance getter

### DIFF
--- a/contracts/Obligation.sol
+++ b/contracts/Obligation.sol
@@ -416,8 +416,27 @@ contract Obligation is IObligation, IERC20, European, Ownable, WriterRegistry {
      * @param account An account which owns obligations.
      * @return The total balance of the account.
      **/
-    function balanceObl(address account) external view returns (uint256) {
+    function obligations(address account)
+        external
+        override
+        view
+        returns (uint256)
+    {
         return _obligations[account];
+    }
+
+    /**
+     * @notice Returns the obligations available to exercise for an account.
+     * @param account An account which owns obligations.
+     * @return The total exercisable balance of the account.
+     **/
+    function available(address account)
+        external
+        override
+        view
+        returns (uint256)
+    {
+        return _obligations[account].sub(_locked[account]);
     }
 
     /// @dev See {IERC20-transfer}

--- a/contracts/interface/IObligation.sol
+++ b/contracts/interface/IObligation.sol
@@ -21,6 +21,10 @@ interface IObligation {
 
     function treasury() external returns (address);
 
+    function obligations(address account) external view returns (uint256);
+
+    function available(address account) external view returns (uint256);
+
     function mint(
         address account,
         address pool,

--- a/test/contracts/obligation.test.ts
+++ b/test/contracts/obligation.test.ts
@@ -151,7 +151,7 @@ describe('Obligation.sol', () => {
       btcHash,
       Script.p2sh
     );
-    const obligationBalance = await obligation.balanceObl(bobAddress);
+    const obligationBalance = await obligation.obligations(bobAddress);
     expect(obligationBalance).to.eq(amountIn);
 
     return evmSnapFastForward(1000, async () => {
@@ -306,7 +306,7 @@ describe('Obligation.sol', () => {
 
     return evmSnapFastForward(2000, async () => {
       await reconnect(obligation, ObligationFactory, bob).refund(amountIn);
-      const obligationBalance = await obligation.balanceObl(bobAddress);
+      const obligationBalance = await obligation.obligations(bobAddress);
       expect(obligationBalance).to.eq(constants.Zero);
     });
   });
@@ -332,7 +332,7 @@ describe('Obligation.sol', () => {
 
     // alice sells obligations to bob (pool)
     await obligation.transfer(bobAddress, amountIn);
-    const obligationBalanceAlice0 = await obligation.balanceObl(aliceAddress);
+    const obligationBalanceAlice0 = await obligation.obligations(aliceAddress);
     expect(obligationBalanceAlice0).to.eq(amountIn);
     const poolBalance = await obligation.balanceOf(bobAddress);
     expect(poolBalance).to.eq(amountIn);
@@ -348,14 +348,14 @@ describe('Obligation.sol', () => {
       charlieAddress,
       amountIn
     );
-    const obligationBalanceCharlie = await obligation.balanceObl(
+    const obligationBalanceCharlie = await obligation.obligations(
       charlieAddress
     );
     expect(obligationBalanceCharlie).to.eq(amountIn);
 
     // alice can now withdraw her collateral
     await obligation.withdraw(amountIn, bobAddress);
-    const obligationBalanceAlice1 = await obligation.balanceObl(aliceAddress);
+    const obligationBalanceAlice1 = await obligation.obligations(aliceAddress);
     expect(obligationBalanceAlice1).to.eq(constants.Zero);
   });
 });

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -324,7 +324,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**18]', () => {
       const optionBalance = await option.balanceOf(bobAddress);
       expect(optionBalance, 'bob should have no options').to.eq(constants.Zero);
 
-      const obligationBalance = await obligation.balanceObl(aliceAddress);
+      const obligationBalance = await obligation.obligations(aliceAddress);
       expect(obligationBalance).to.eq(collateralAmount.sub(amountOut));
     });
   });
@@ -485,7 +485,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**6]', () => {
       const optionBalance = await option.balanceOf(bobAddress);
       expect(optionBalance, 'bob should have no options').to.eq(constants.Zero);
 
-      const obligationBalance = await obligation.balanceObl(aliceAddress);
+      const obligationBalance = await obligation.obligations(aliceAddress);
       expect(obligationBalance).to.eq(collateralAmount.sub(amountOut));
     });
   });
@@ -593,13 +593,13 @@ describe('Put Option (1 Writer, 1 Buyer) - Refund Options [10**18]', () => {
   });
 
   it('alice should refund options after expiry', async () => {
-    const obligationBalance = await obligation.balanceObl(aliceAddress);
+    const obligationBalance = await obligation.obligations(aliceAddress);
     expect(obligationBalance).to.eq(collateralAmount);
     await evmSnapFastForward(2000, async () => {
       await reconnect(obligation, ObligationFactory, alice).refund(
         collateralAmount
       );
-      const obligationBalance = await obligation.balanceObl(aliceAddress);
+      const obligationBalance = await obligation.obligations(aliceAddress);
       expect(obligationBalance).to.eq(constants.Zero);
       const collateralBalance = await collateral.balanceOf(aliceAddress);
       expect(collateralBalance).to.eq(collateralAmount);
@@ -763,7 +763,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Transfer Obligations [10**18]', () =>
       [collateral.address, obligation.address]
     );
 
-    const obligationBalance = await obligation.balanceObl(eveAddress);
+    const obligationBalance = await obligation.obligations(eveAddress);
     expect(obligationBalance).to.eq(amountOut);
 
     const collateralBalance = await collateral.balanceOf(eveAddress);
@@ -857,7 +857,7 @@ describe('Put Option (2 Writers, 1 Buyer) - Transfer Obligations [10*18]', () =>
         Script.p2sh
       );
 
-      const obligationBalance = await obligation.balanceObl(address);
+      const obligationBalance = await obligation.obligations(address);
       expect(obligationBalance).to.eq(collateralAmount);
     };
 
@@ -933,7 +933,7 @@ describe('Put Option (2 Writers, 1 Buyer) - Transfer Obligations [10*18]', () =>
       [collateral.address, obligation.address]
     );
 
-    const obligationBalance = await obligation.balanceObl(bobAddress);
+    const obligationBalance = await obligation.obligations(bobAddress);
     expect(obligationBalance).to.eq(amountOut);
     const collateralBalance = await collateral.balanceOf(bobAddress);
     expect(collateralBalance).to.eq(amountInMax.sub(input));
@@ -1020,7 +1020,7 @@ describe('Put Option (2 Writers, 1 Buyer) - Transfer Obligations [10*18]', () =>
 //         Script.p2sh
 //       );
 
-//     // const obligationBalance = (await obligation.balanceObl(address)).toNumber();
+//     // const obligationBalance = (await obligation.obligations(address)).toNumber();
 //     // expect(obligationBalance).to.eq(collateralAmount);
 //   };
 
@@ -1075,10 +1075,10 @@ describe('Put Option (2 Writers, 1 Buyer) - Transfer Obligations [10*18]', () =>
 //           Buffer.alloc(32, 0)
 //         );
 
-//       const obligationBalance1 = (await obligation.balanceObl(addresses[1])).toNumber();
+//       const obligationBalance1 = (await obligation.obligations(addresses[1])).toNumber();
 //       expect(obligationBalance1).to.eq(collateralAmounts[0] - 115);
 
-//       const obligationBalance2 = (await obligation.balanceObl(addresses[2])).toNumber();
+//       const obligationBalance2 = (await obligation.obligations(addresses[2])).toNumber();
 //       expect(obligationBalance2).to.eq(6560);
 //     });
 //   });


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

Rename `balanceObl` to `obligations` and add a getter `available` which returns the number of obligations for an account minus active requests - the total number which can be exercised.