### PR TITLE
remove nonce construct, update relay

### DIFF
--- a/contracts/interface/IObligation.sol
+++ b/contracts/interface/IObligation.sol
@@ -45,10 +45,11 @@ interface IObligation {
     function requestExercise(address seller, uint256 satoshis) external;
 
     function executeExercise(
-        bytes32 reqid,
-        uint256 height,
+        bytes32 id,
+        uint32 height,
         uint256 index,
         bytes32 txid,
+        bytes calldata header,
         bytes calldata proof,
         bytes calldata rawtx
     ) external;

--- a/contracts/interface/IReferee.sol
+++ b/contracts/interface/IReferee.sol
@@ -5,24 +5,14 @@ pragma solidity ^0.6.0;
 import {Bitcoin} from '../types/Bitcoin.sol';
 
 interface IReferee {
-    /**
-     * @notice Verify transaction inclusion / format
-     * @param height Bitcoin block height
-     * @param index Bitcoin tx index
-     * @param txid Bitcoin transaction id
-     * @param proof Bitcoin inclusion proof
-     * @param rawtx Bitcoin raw tx
-     * @param btcHash Bitcoin address hash
-     * @param format Bitcoin script format
-     * @return Bitcoin output satoshis
-     **/
     function verifyTx(
-        uint256 height,
+        uint32 height,
         uint256 index,
         bytes32 txid,
+        bytes calldata header,
         bytes calldata proof,
         bytes calldata rawtx,
         bytes20 btcHash,
         Bitcoin.Script format
-    ) external view returns (uint256);
+    ) external returns (uint256);
 }

--- a/contracts/interface/IRelay.sol
+++ b/contracts/interface/IRelay.sol
@@ -4,9 +4,10 @@ pragma solidity ^0.6.0;
 
 interface IRelay {
     function verifyTx(
-        uint256 height,
+        uint32 height,
         uint256 index,
         bytes32 txid,
+        bytes calldata header,
         bytes calldata proof,
         uint256 confirmations,
         bool insecure

--- a/contracts/test/MockBTCReferee.sol
+++ b/contracts/test/MockBTCReferee.sol
@@ -11,10 +11,10 @@ contract MockBTCReferee is BTCReferee {
     }
 
     function extractOutputValue(
-        bytes calldata rawTx,
+        bytes calldata rawtx,
         bytes20 btcHash,
         Bitcoin.Script format
     ) external pure returns (uint256) {
-        return _extractOutputValue(rawTx, btcHash, format);
+        return _extractOutputValue(rawtx, btcHash, format);
     }
 }

--- a/contracts/test/MockRelay.sol
+++ b/contracts/test/MockRelay.sol
@@ -6,9 +6,10 @@ import {IRelay} from '../interface/IRelay.sol';
 
 contract MockRelay is IRelay {
     function verifyTx(
-        uint256,
+        uint32,
         uint256,
         bytes32,
+        bytes calldata,
         bytes calldata,
         uint256,
         bool

--- a/lib/contracts.ts
+++ b/lib/contracts.ts
@@ -92,7 +92,7 @@ export function getRequestEvent(
 ): Promise<Result> {
   const fragment =
     obligation.interface.events[
-      'RequestExercise(address,address,bytes32,uint256,uint256)'
+      'RequestExercise(address,address,bytes32,uint256)'
     ];
   return getEvent(fragment, [buyer, seller], receipt, obligation);
 }
@@ -190,13 +190,14 @@ export interface WriteOptionPair extends ReadOptionPair {
     amountInMax: BigNumberish
   ): Promise<void>;
 
-  requestExercise(seller: string, satoshis: BigNumberish): Promise<BigNumber>;
+  requestExercise(seller: string, satoshis: BigNumberish): Promise<void>;
 
   executeExercise(
     seller: string,
     height: BigNumberish,
     index: BigNumberish,
     txid: BytesLike,
+    header: BytesLike,
     proof: BytesLike,
     rawtx: BytesLike
   ): Promise<void>;
@@ -347,14 +348,10 @@ export class ReadWriteOptionPair extends ReadOnlyOptionPair
       .then((tx) => tx.wait(this.confirmations));
   }
 
-  async requestExercise(
-    seller: string,
-    satoshis: BigNumberish
-  ): Promise<BigNumber> {
+  async requestExercise(seller: string, satoshis: BigNumberish): Promise<void> {
     await this.obligation
       .requestExercise(seller, satoshis)
       .then((tx) => tx.wait(this.confirmations));
-    return this.obligation.getSecret(seller);
   }
 
   // prove inclusion and claim collateral
@@ -363,11 +360,12 @@ export class ReadWriteOptionPair extends ReadOnlyOptionPair
     height: BigNumberish,
     index: BigNumberish,
     txid: BytesLike,
+    header: BytesLike,
     proof: BytesLike,
     rawtx: BytesLike
   ): Promise<void> {
     await this.obligation
-      .executeExercise(seller, height, index, txid, proof, rawtx)
+      .executeExercise(seller, height, index, txid, header, proof, rawtx)
       .then((tx) => tx.wait(this.confirmations));
   }
 

--- a/test/contracts/obligation.test.ts
+++ b/test/contracts/obligation.test.ts
@@ -176,6 +176,7 @@ describe('Obligation.sol', () => {
         0,
         constants.HashZero,
         constants.HashZero,
+        constants.HashZero,
         constants.HashZero
       );
       await expect(result).to.be.revertedWith(ErrorCode.ERR_INVALID_REQUEST);
@@ -206,10 +207,12 @@ describe('Obligation.sol', () => {
         bobAddress,
         await requestTx.wait(0)
       );
+      await referee.mock.verifyTx.returns(amountOutSat.sub(1000));
       const result = obligation.executeExercise(
         requestEvent.id,
         0,
         0,
+        constants.HashZero,
         constants.HashZero,
         constants.HashZero,
         constants.HashZero
@@ -244,13 +247,12 @@ describe('Obligation.sol', () => {
         bobAddress,
         await requestTx.wait(0)
       );
-      await referee.mock.verifyTx.returns(
-        amountOutSat.add(requestEvent.secret)
-      );
+      await referee.mock.verifyTx.returns(amountOutSat);
       const tx = await obligation.executeExercise(
         requestEvent.id,
         0,
         0,
+        constants.HashZero,
         constants.HashZero,
         constants.HashZero,
         constants.HashZero

--- a/test/options.test.ts
+++ b/test/options.test.ts
@@ -305,14 +305,13 @@ describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**18]', () => {
         await requestTx.wait(0)
       );
 
-      await btcReferee.mock.verifyTx.returns(
-        amountOutSat.add(requestEvent.secret)
-      );
+      await btcReferee.mock.verifyTx.returns(amountOutSat);
 
       await reconnect(obligation, ObligationFactory, bob).executeExercise(
         requestEvent.id,
         0,
         0,
+        constants.HashZero,
         constants.HashZero,
         constants.HashZero,
         constants.HashZero
@@ -463,14 +462,13 @@ describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**6]', () => {
         await requestTx.wait(0)
       );
 
-      await btcReferee.mock.verifyTx.returns(
-        amountOutSat.add(requestEvent.secret)
-      );
+      await btcReferee.mock.verifyTx.returns(amountOutSat);
 
       await reconnect(obligation, ObligationFactory, bob).executeExercise(
         requestEvent.id,
         0,
         0,
+        constants.HashZero,
         constants.HashZero,
         constants.HashZero,
         constants.HashZero


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

After discussion with @alexeiZamyatin offline, we have chosen to discontinue the nonce based replay protection (previously highlighted in #14 and #30) due to it's limited security. Pending full `OP_RETURN` support, this PR removes the prior scheme and adds a disclaimer.