### PR TITLE
Fix bug in test data deployment

### DIFF
--- a/lib/contracts.ts
+++ b/lib/contracts.ts
@@ -23,6 +23,8 @@ import {SignerOrProvider, Optional, Signer, Provider} from './core';
 import {Addresses, resolveAddresses} from './addresses';
 import {EventFragment, Result} from 'ethers/lib/utils';
 
+export type AddressesPair = {option: string; obligation: string};
+
 interface Connectable<C> {
   connect: (addr: string, signer: SignerOrProvider) => C;
 }
@@ -116,12 +118,12 @@ export async function createPair(
   collateral: string,
   referee: string,
   confirmations?: number
-): Promise<string> {
+): Promise<AddressesPair> {
   const receipt = await optionFactory
     .createPair(expiryTime, windowSize, strikePrice, collateral, referee)
     .then((tx) => tx.wait(confirmations));
   const event = await getCreatePairEvent(optionFactory, receipt);
-  return event.option;
+  return {option: event.option, obligation: event.obligation};
 }
 
 export type BtcAddress = {
@@ -560,7 +562,7 @@ export class ReadWriteContracts extends ReadOnlyContracts
     windowSize: BigNumberish,
     strikePrice: BigNumberish
   ): Promise<WriteOptionPair> {
-    const optionAddress = await createPair(
+    const {option} = await createPair(
       this.optionFactory,
       expiryTime,
       windowSize,
@@ -569,7 +571,7 @@ export class ReadWriteContracts extends ReadOnlyContracts
       this.referee.address,
       this.confirmations
     );
-    return this.getPair(optionAddress);
+    return this.getPair(option);
   }
 
   async getPair(optionAddress: string): Promise<WriteOptionPair> {

--- a/scripts/testdata.ts
+++ b/scripts/testdata.ts
@@ -9,7 +9,8 @@ import {
   reconnect,
   deploy2,
   createPair,
-  deploy1
+  deploy1,
+  AddressesPair
 } from '../lib/contracts';
 import {newBigNum} from '../lib/conversion';
 import {OptionPairFactoryFactory} from '../typechain/OptionPairFactoryFactory';
@@ -46,8 +47,8 @@ async function createAndLockAndWrite(
   referee: BtcReferee,
   premium: BigNumber,
   amount: BigNumber
-): Promise<string> {
-  const optionAddress = await createPair(
+): Promise<AddressesPair> {
+  const addressesPair = await createPair(
     optionFactory,
     expiryTime,
     windowSize,
@@ -55,16 +56,16 @@ async function createAndLockAndWrite(
     collateral.address,
     referee.address
   );
-  const option = OptionFactory.connect(optionAddress, signer);
+  const obligation = OptionFactory.connect(addressesPair.obligation, signer);
 
-  console.log('Adding data to option: ', optionAddress);
+  console.log('Adding data to obligation: ', obligation.address);
   await reconnect(collateral, MockCollateralFactory, signer).approve(
     optionLib.address,
     amount.add(premium)
   );
 
   await reconnect(optionLib, OptionLibFactory, signer).lockAndWrite(
-    option.address,
+    obligation.address,
     collateral.address,
     collateral.address,
     amount,
@@ -75,7 +76,7 @@ async function createAndLockAndWrite(
     Script.p2pkh
   );
 
-  return optionAddress;
+  return addressesPair;
 }
 
 async function main(): Promise<void> {

--- a/test/common.ts
+++ b/test/common.ts
@@ -21,7 +21,7 @@ export async function deployPair(
   option: Option;
   obligation: Obligation;
 }> {
-  const optionAddress = await createPair(
+  const pairAddresses = await createPair(
     optionFactory,
     expiryTime,
     windowSize,
@@ -29,7 +29,7 @@ export async function deployPair(
     collateral,
     btcReferee
   );
-  const option = OptionFactory.connect(optionAddress, signer);
+  const option = OptionFactory.connect(pairAddresses.option, signer);
 
   const obligationAddress = await optionFactory.getObligation(option.address);
   const obligation = ObligationFactory.connect(obligationAddress, signer);


### PR DESCRIPTION
 `lockAndWrite` expects the obligation address but was given the option so the data deployment was not working.
This should fix it.