### PR TITLE
allow re-use of collateral subject to position

### DIFF
--- a/buidler.config.ts
+++ b/buidler.config.ts
@@ -35,7 +35,7 @@ const config = {
   defaultNetwork: 'buidlerevm',
   solc: {
     version: '0.6.6',
-    optimizer: {enabled: true, runs: 200}
+    optimizer: {enabled: true, runs: 300}
   },
   paths: {
     sources: './contracts',

--- a/contracts/European.sol
+++ b/contracts/European.sol
@@ -3,13 +3,14 @@
 pragma solidity ^0.6.0;
 
 import {SafeMath} from '@openzeppelin/contracts/math/SafeMath.sol';
+import {IEuropean} from './interface/IEuropean.sol';
 
 /**
  * @dev Contract module which provides a timed access control mechanism,
  * specifically to model a European Option with an expiry and settlement phase.
  * It must be used through inheritance which provides several modifiers.
  */
-contract European {
+contract European is IEuropean {
     using SafeMath for uint256;
 
     string internal constant ERR_INIT_EXPIRED = 'Cannot init expired';
@@ -18,10 +19,10 @@ contract European {
     string internal constant ERR_WINDOW_ZERO = 'Window cannot be zero';
 
     // expiry timestamp
-    uint256 public expiryTime;
+    uint256 public override expiryTime;
 
     // window post expiry
-    uint256 public windowSize;
+    uint256 public override windowSize;
 
     modifier setExpiry(uint256 _expiryTime, uint256 _windowSize) {
         require(_expiryTime > block.timestamp, ERR_INIT_EXPIRED);
@@ -63,11 +64,10 @@ contract European {
     }
 
     /**
-     * @dev Throws if called before the exercise window has expired
+     * @dev Returns true if the `expiryTime + windowSize` has elapsed.
      */
-    modifier canRefund() {
+    function canExit() external override returns (bool) {
         // solium-disable-next-line security/no-block-members
-        require(block.timestamp > expiryTime.add(windowSize), ERR_NOT_EXPIRED);
-        _;
+        return block.timestamp > expiryTime.add(windowSize);
     }
 }

--- a/contracts/OptionPairFactory.sol
+++ b/contracts/OptionPairFactory.sol
@@ -35,6 +35,7 @@ contract OptionPairFactory is IOptionPairFactory, Ownable {
     );
 
     address internal uniswap;
+    address[] public options;
 
     mapping(address => address) public getTreasury;
 
@@ -127,8 +128,7 @@ contract OptionPairFactory is IOptionPairFactory, Ownable {
         // fail early if the collateral asset has not been whitelisted
         require(isEnabled[collateral], ERR_NOT_SUPPORTED);
 
-        // load treasury for collateral type or create
-        // a new treasury if it does not exist yet
+        // load treasury for collateral type
         address treasury = getTreasury[collateral];
         require(treasury != address(0), ERR_NO_TREASURY);
 
@@ -162,6 +162,7 @@ contract OptionPairFactory is IOptionPairFactory, Ownable {
         );
         Ownable(option).transferOwnership(obligation);
         ITreasury(treasury).authorize(obligation);
+        options.push(option);
 
         emit CreatePair(
             option,
@@ -171,5 +172,9 @@ contract OptionPairFactory is IOptionPairFactory, Ownable {
             windowSize,
             strikePrice
         );
+    }
+
+    function allOptions() external override view returns (address[] memory) {
+        return options;
     }
 }

--- a/contracts/Treasury.sol
+++ b/contracts/Treasury.sol
@@ -4,19 +4,23 @@ pragma solidity ^0.6.0;
 
 import '@nomiclabs/buidler/console.sol';
 
+import {Ownable} from '@openzeppelin/contracts/access/Ownable.sol';
 import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import {SafeMath} from '@openzeppelin/contracts/math/SafeMath.sol';
 import {
     ReentrancyGuard
 } from '@openzeppelin/contracts/utils/ReentrancyGuard.sol';
 import {ITreasury} from './interface/ITreasury.sol';
+import {IEuropean} from './interface/IEuropean.sol';
+import {IObligation} from './interface/IObligation.sol';
+import {Bitcoin} from './types/Bitcoin.sol';
+import {WriterRegistry} from './WriterRegistry.sol';
 
 /// @title Treasury ERC20
 /// @author Interlay
 /// @notice This contract manages locking and unlocking of collateral.
-/// @dev This should not be ownable since it may be shared across factories.
 /// @dev All operations MUST be called atomically to prevent misappropriation.
-contract Treasury is ITreasury, ReentrancyGuard {
+contract Treasury is ITreasury, ReentrancyGuard, Ownable, WriterRegistry {
     using SafeMath for uint256;
 
     string
@@ -25,6 +29,15 @@ contract Treasury is ITreasury, ReentrancyGuard {
         internal constant ERR_INSUFFICIENT_LOCKED = 'Insufficient collateral locked';
     string
         internal constant ERR_INSUFFICIENT_UNLOCKED = 'Insufficient collateral unlocked';
+    string
+        internal constant ERR_POSITION_INVALID_EXPIRY = 'Invalid position expiry';
+    string internal constant ERR_POSITION_NOT_SET = 'Position not set';
+    string internal constant ERR_POSITION_NOT_EXPIRED = 'Position not expired';
+    string internal constant ERR_NOT_AUTHORIZED = 'Caller not authorized';
+    string internal constant ERR_MARKET_HAS_EXPIRED = 'Market has expired';
+    string internal constant ERR_MARKET_NOT_EXPIRED = 'Market not expired';
+    string internal constant ERR_MARKET_EXPIRY = 'Market expiry invalid';
+    string internal constant ERR_MARKET_STRIKE = 'Market strike invalid';
 
     /// @notice The address of the collateral ERC20
     /// @return address of the ERC20 contract
@@ -32,20 +45,43 @@ contract Treasury is ITreasury, ReentrancyGuard {
 
     uint256 internal reserve;
 
-    // obligation -> user -> amount
+    // market -> user -> amount
     mapping(address => mapping(address => uint256)) internal _locked;
-    mapping(address => mapping(address => uint256)) internal _unlocked;
+    mapping(address => uint256) internal _unlocked;
+    mapping(address => uint256) internal _balances;
+
+    mapping(address => bool) internal _isAuthorized;
+
+    struct Position {
+        uint256 minStrike;
+        uint256 maxStrike;
+        uint256 expiryTime;
+    }
+
+    mapping(address => Position) internal _positions;
 
     /// @notice Initialize the treasury contract against an ERC20 token.
     /// @param _collateral address of the ERC20
-    constructor(address _collateral) public {
+    constructor(address _collateral, address owner) public Ownable() {
         collateral = _collateral;
+        transferOwnership(owner);
     }
 
-    /// @notice Returns the balance of an `account` under a particular `market`.
+    /// @notice Returns the total collateral written by an `account`.
+    /// @param account Address of the supplier
+    function balanceOf(address account)
+        external
+        override
+        view
+        returns (uint256)
+    {
+        return _balances[account];
+    }
+
+    /// @notice Returns the total collateral locked in a `market` by an `account`.
     /// @param market Address of the market
     /// @param account Address of the supplier
-    function balanceOf(address market, address account)
+    function lockedIn(address market, address account)
         external
         override
         view
@@ -54,47 +90,111 @@ contract Treasury is ITreasury, ReentrancyGuard {
         return _locked[market][account];
     }
 
+    /// @notice Set the caller's position for all held collateral.
+    /// @param minStrike Minimum strike price
+    /// @param maxStrike Maximum strike price
+    /// @param expiryTime Final expiry time
+    /// @param btcHash Bitcoin address hash
+    /// @param format Bitcoin address format
+    function position(
+        uint256 minStrike,
+        uint256 maxStrike,
+        uint256 expiryTime,
+        bytes20 btcHash,
+        Bitcoin.Script format
+    ) external {
+        // solium-disable-next-line security/no-block-members
+        require(expiryTime >= block.timestamp, ERR_POSITION_INVALID_EXPIRY);
+        require(
+            expiryTime >= _positions[msg.sender].expiryTime,
+            ERR_POSITION_INVALID_EXPIRY
+        );
+
+        _positions[msg.sender].minStrike = minStrike;
+        _positions[msg.sender].maxStrike = maxStrike;
+        _positions[msg.sender].expiryTime = expiryTime;
+        _setBtcAddress(msg.sender, btcHash, format);
+    }
+
+    function authorize(address account) external override onlyOwner {
+        _isAuthorized[account] = true;
+    }
+
     /// @notice Deposit collateral in the specified `market`. Assumes
     /// collateral has been transferred within the same transaction and claims
     /// the unreserved balance since the last deposit.
     /// @dev Once 'unlocked' the caller must atomically write options or buy obligations
     /// to prevent misapproriation.
-    /// @param market Address of the market
     /// @param account Address of the supplier
-    function deposit(address market, address account)
-        external
-        override
-        nonReentrant
-    {
+    function deposit(address account) external override nonReentrant {
+        require(_positions[account].expiryTime > 0, ERR_POSITION_NOT_SET);
         uint256 balance = IERC20(collateral).balanceOf(address(this));
         uint256 amount = balance.sub(reserve);
+        _balances[account] = _balances[account].add(amount);
         require(amount > 0, ERR_INSUFFICIENT_DEPOSIT);
-        _unlocked[market][account] = _unlocked[market][account].add(amount);
+        _unlocked[account] = _unlocked[account].add(amount);
         reserve = balance;
     }
 
     /// @notice Lock collateral for the caller, assuming sufficient
     /// funds have been deposited against the market.
-    /// @dev Reverts if if there is insufficient funds 'unlocked'.
+    /// @dev Reverts if there is insufficient funds 'unlocked'.
     /// @param account Ethereum address that locks collateral
     /// @param amount The amount to be locked
+    /// @return btcHash Bitcoin hash
+    /// @return format Bitcoin script format
     function lock(address account, uint256 amount)
         external
         override
         nonReentrant
+        returns (bytes20 btcHash, Bitcoin.Script format)
     {
-        _unlocked[msg.sender][account] = _unlocked[msg.sender][account].sub(
+        address market = msg.sender;
+        require(_isAuthorized[market], ERR_NOT_AUTHORIZED);
+
+        (uint256 expiry, uint256 window, uint256 strike, , , ) = IObligation(
+            market
+        )
+            .getDetails();
+
+        // check option expiry + window
+        // cannot lapse after position
+        require(
+            expiry.add(window) <= _positions[account].expiryTime,
+            ERR_MARKET_EXPIRY
+        );
+        // check strike is within range
+        require(
+            strike >= _positions[account].minStrike &&
+                strike <= _positions[account].maxStrike,
+            ERR_MARKET_STRIKE
+        );
+
+        _unlocked[account] = _unlocked[account].sub(
             amount,
             ERR_INSUFFICIENT_UNLOCKED
         );
-        _locked[msg.sender][account] = _locked[msg.sender][account].add(amount);
+        _locked[market][account] = _locked[market][account].add(amount);
+
+        return _getBtcAddress(account);
     }
 
-    /// @notice Release collateral for a specific account owned by
-    /// the caller. For instance, if an account has exercised or
-    /// refunded their options against a specific market (obligation),
-    /// after performing the necessary correctness checks that contract
-    /// should call this function.
+    function unlock(
+        address market,
+        address account,
+        uint256 amount
+    ) external override {
+        require(IEuropean(market).canExit(), ERR_MARKET_NOT_EXPIRED);
+        _locked[market][account] = _locked[market][account].sub(
+            amount,
+            ERR_INSUFFICIENT_LOCKED
+        );
+        _unlocked[account] = _unlocked[account].add(amount);
+    }
+
+    /// @notice Release collateral for a specific market. For instance,
+    /// if an account has successfully exercised against a specific market
+    /// it should call this function to release the funds.
     /// @param from Ethereum address that locked collateral
     /// @param to Ethereum address to receive collateral
     /// @param amount The amount to be unlocked
@@ -103,11 +203,27 @@ contract Treasury is ITreasury, ReentrancyGuard {
         address to,
         uint256 amount
     ) external override nonReentrant {
-        _locked[msg.sender][from] = _locked[msg.sender][from].sub(
+        address market = msg.sender;
+        _locked[market][from] = _locked[market][from].sub(
             amount,
             ERR_INSUFFICIENT_LOCKED
         );
+        _balances[from] = _balances[from].sub(amount);
         IERC20(collateral).transfer(to, amount);
+        reserve = IERC20(collateral).balanceOf(address(this));
+    }
+
+    /// @notice Allows a writer to withdraw their collateral after their
+    /// position has expired.
+    /// @param amount The amount to be redeemed
+    function withdraw(uint256 amount) external {
+        address sender = msg.sender;
+        require(
+            block.timestamp > _positions[sender].expiryTime,
+            ERR_POSITION_NOT_EXPIRED
+        );
+        _balances[sender] = _balances[sender].sub(amount);
+        IERC20(collateral).transfer(sender, amount);
         reserve = IERC20(collateral).balanceOf(address(this));
     }
 }

--- a/contracts/WriterRegistry.sol
+++ b/contracts/WriterRegistry.sol
@@ -40,6 +40,14 @@ contract WriterRegistry is IWriterRegistry {
         _setBtcAddress(msg.sender, btcHash, format);
     }
 
+    function _getBtcAddress(address account)
+        internal
+        view
+        returns (bytes20 btcHash, Bitcoin.Script format)
+    {
+        return (_btcAddresses[account].btcHash, _btcAddresses[account].format);
+    }
+
     /**
      * @notice Get the configured BTC address for an account.
      * @param account Minter address
@@ -52,7 +60,7 @@ contract WriterRegistry is IWriterRegistry {
         view
         returns (bytes20 btcHash, Bitcoin.Script format)
     {
-        return (_btcAddresses[account].btcHash, _btcAddresses[account].format);
+        return _getBtcAddress(account);
     }
 
     /**

--- a/contracts/interface/IEuropean.sol
+++ b/contracts/interface/IEuropean.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.6.0;
+
+interface IEuropean {
+    function expiryTime() external returns (uint256);
+
+    function windowSize() external returns (uint256);
+
+    function canExit() external returns (bool);
+}

--- a/contracts/interface/IObligation.sol
+++ b/contracts/interface/IObligation.sol
@@ -2,8 +2,6 @@
 
 pragma solidity ^0.6.0;
 
-import {Bitcoin} from '../types/Bitcoin.sol';
-
 interface IObligation {
     function initialize(
         uint8 _decimals,
@@ -12,7 +10,8 @@ interface IObligation {
         uint256 _strikePrice,
         address _option,
         address _referee,
-        address _treasury
+        address _treasury,
+        address _uniswap
     ) external;
 
     function getDetails()
@@ -37,13 +36,7 @@ interface IObligation {
 
     function available(address account) external view returns (uint256);
 
-    function mint(
-        address account,
-        address pool,
-        uint256 amount,
-        bytes20 btcHash,
-        Bitcoin.Script format
-    ) external;
+    function mint(address account, uint256 amount) external;
 
     function requestExercise(address seller, uint256 satoshis) external;
 
@@ -56,8 +49,6 @@ interface IObligation {
         bytes calldata proof,
         bytes calldata rawtx
     ) external;
-
-    function refund(uint256 amount) external;
 
     function withdraw(uint256 amount, address pool) external;
 }

--- a/contracts/interface/IOption.sol
+++ b/contracts/interface/IOption.sol
@@ -11,7 +11,11 @@ interface IOption {
         uint256 _windowSize
     ) external;
 
-    function mint(address account, uint256 amount) external;
+    function mint(
+        address writer,
+        address pair,
+        uint256 amount
+    ) external;
 
     function requestExercise(address buyer, uint256 satoshis) external;
 }

--- a/contracts/interface/IOptionPairFactory.sol
+++ b/contracts/interface/IOptionPairFactory.sol
@@ -12,6 +12,4 @@ interface IOptionPairFactory {
         address referee,
         address collateral
     ) external returns (address option, address obligation);
-
-    function allOptions() external view returns (address[] memory);
 }

--- a/contracts/interface/IOptionPairFactory.sol
+++ b/contracts/interface/IOptionPairFactory.sol
@@ -16,4 +16,6 @@ interface IOptionPairFactory {
         address referee,
         address collateral
     ) external returns (address option, address obligation);
+
+    function allOptions() external view returns (address[] memory);
 }

--- a/contracts/interface/ITreasury.sol
+++ b/contracts/interface/ITreasury.sol
@@ -2,21 +2,35 @@
 
 pragma solidity ^0.6.0;
 
+import {Bitcoin} from '../types/Bitcoin.sol';
+
 interface ITreasury {
     function collateral() external view returns (address);
 
-    function balanceOf(address market, address account)
+    function balanceOf(address account) external view returns (uint256);
+
+    function lockedIn(address market, address account)
         external
         view
         returns (uint256);
 
-    function deposit(address market, address account) external;
+    function deposit(address account) external;
 
-    function lock(address account, uint256 amount) external;
+    function lock(address account, uint256 amount)
+        external
+        returns (bytes20 btcHash, Bitcoin.Script format);
+
+    function unlock(
+        address market,
+        address account,
+        uint256 amount
+    ) external;
 
     function release(
         address from,
         address to,
         uint256 amount
     ) external;
+
+    function authorize(address option) external;
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -12,6 +12,9 @@ export const ErrorCode = {
   ERR_APPROVE_FROM_ZERO_ADDRESS: 'Approve from zero address',
   ERR_TRANSFER_FROM_ZERO_ADDRESS: 'Transfer from zero address',
 
+  // OptionPairFactory
+  ERR_NO_TREASURY: 'No treasury found',
+
   // Expirable
   ERR_INIT_EXPIRED: 'Cannot init expired',
   ERR_EXPIRED: 'Contract has expired',
@@ -31,6 +34,14 @@ export const ErrorCode = {
   ERR_INSUFFICIENT_DEPOSIT: 'Insufficient deposit amount',
   ERR_INSUFFICIENT_LOCKED: 'Insufficient collateral locked',
   ERR_INSUFFICIENT_UNLOCKED: 'Insufficient collateral unlocked',
+  ERR_POSITION_INVALID_EXPIRY: 'Invalid position expiry',
+  ERR_POSITION_NOT_SET: 'Position not set',
+  ERR_POSITION_NOT_EXPIRED: 'Position not expired',
+  ERR_NOT_AUTHORIZED: 'Caller not authorized',
+  ERR_MARKET_HAS_EXPIRED: 'Market has expired',
+  ERR_MARKET_NOT_EXPIRED: 'Market not expired',
+  ERR_MARKET_EXPIRY: 'Market expiry invalid',
+  ERR_MARKET_STRIKE: 'Market strike invalid',
 
   // WriterRegistry
   ERR_NO_BTC_HASH: 'Cannot set empty BTC address',

--- a/lib/contracts.ts
+++ b/lib/contracts.ts
@@ -186,8 +186,6 @@ export interface WriteOptionPair extends ReadOptionPair {
     proof: BytesLike,
     rawtx: BytesLike
   ): ConfirmationNotifier;
-
-  refund(amount: BigNumberish): ConfirmationNotifier;
 }
 
 export class ReadOnlyOptionPair implements ReadOptionPair {
@@ -225,7 +223,7 @@ export class ReadOnlyOptionPair implements ReadOptionPair {
   // gets the locked collateral for a pair
   // total number of USDT written
   async totalSupplied(account: string): Promise<BigNumber> {
-    return this.treasury.balanceOf(this.obligation.address, account);
+    return this.treasury.lockedIn(this.obligation.address, account);
   }
 
   async totalWritten(account: string): Promise<BigNumber> {
@@ -259,6 +257,7 @@ export class ReadWriteOptionPair extends ReadOnlyOptionPair
     amount: BigNumberish,
     btcAddress: BtcAddress
   ): ConfirmationNotifier {
+    // TODO: write position
     return this.waitConfirm(
       this.optionLib.lockAndWrite(
         this.option.address,
@@ -267,9 +266,7 @@ export class ReadWriteOptionPair extends ReadOnlyOptionPair
         amount,
         premium,
         amount,
-        premium,
-        btcAddress.hash,
-        btcAddress.format
+        premium
       )
     );
   }
@@ -352,11 +349,6 @@ export class ReadWriteOptionPair extends ReadOnlyOptionPair
         rawtx
       )
     );
-  }
-
-  // claim written collateral after expiry
-  refund(amount: BigNumberish): ConfirmationNotifier {
-    return this.waitConfirm(this.obligation.refund(amount));
   }
 
   private waitConfirm(

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   ],
   "homepage": "https://gitlab.com/interlay/xopts#readme",
   "devDependencies": {
+    "@gregdhill/mock-contract": "3.0.4",
     "@interlay/bitcoin-spv-sol": "3.2.2",
     "@interlay/btc-relay-sol": "0.3.10",
     "@nodefactory/buidler-typechain": "^0.2.0",

--- a/test/common.ts
+++ b/test/common.ts
@@ -1,9 +1,10 @@
 import {OptionPairFactory} from '../typechain/OptionPairFactory';
-import {BigNumberish, Signer} from 'ethers';
-import {createPair} from '../lib/contracts';
-import {OptionFactory, ObligationFactory} from '../typechain';
+import {BigNumberish, Signer, constants} from 'ethers';
+import {createPair, deploy1, deploy2} from '../lib/contracts';
+import {OptionFactory, ObligationFactory, TreasuryFactory} from '../typechain';
 import {Obligation} from '../typechain/Obligation';
 import {Option} from '../typechain/Option';
+import {Treasury} from '../typechain/Treasury';
 
 export function getTimeNow(): number {
   return Math.round(new Date().getTime() / 1000);
@@ -20,7 +21,22 @@ export async function deployPair(
 ): Promise<{
   option: Option;
   obligation: Obligation;
+  treasury: Treasury;
 }> {
+  const treasuryAddress = await optionFactory.getTreasury(collateral);
+  let treasury: Treasury;
+  if (treasuryAddress === constants.AddressZero) {
+    treasury = await deploy2(
+      signer,
+      TreasuryFactory,
+      collateral,
+      optionFactory.address
+    );
+    await optionFactory.setTreasuryFor(collateral, treasury.address);
+  } else {
+    treasury = TreasuryFactory.connect(treasuryAddress, signer);
+  }
+
   const pairAddresses = await createPair(
     optionFactory,
     expiryTime,
@@ -30,9 +46,10 @@ export async function deployPair(
     btcReferee
   );
   const option = OptionFactory.connect(pairAddresses.option, signer);
+  const obligation = ObligationFactory.connect(
+    pairAddresses.obligation,
+    signer
+  );
 
-  const obligationAddress = await optionFactory.getObligation(option.address);
-  const obligation = ObligationFactory.connect(obligationAddress, signer);
-
-  return {option, obligation};
+  return {option, obligation, treasury};
 }

--- a/test/contracts/option-pair-factory.test.ts
+++ b/test/contracts/option-pair-factory.test.ts
@@ -79,7 +79,7 @@ describe('OptionPairFactory.sol', () => {
       collateral.address,
       referee.address
     );
-    await expect(result).to.be.revertedWith(ErrorCode.ERR_NO_TREASURY);
+    await expect(result).to.be.revertedWith(ErrorCode.ERR_NOT_SUPPORTED);
   });
 
   it('should fail to create an expired option pair', async () => {

--- a/test/contracts/token-conversion.test.ts
+++ b/test/contracts/token-conversion.test.ts
@@ -90,22 +90,20 @@ describe('Conversion for number of obligation and option tokens with number of s
       }
     ];
 
-    await Promise.all(
-      tests.map(async (t) => {
-        await collateral.mock.decimals.returns(t.decimals);
-        const {obligation} = await deployPair(
-          optionFactory,
-          expiryTime,
-          windowSize,
-          t.strike,
-          collateral.address,
-          constants.AddressZero,
-          alice
-        );
-        const result = await obligation.calculateAmountIn(t.satoshis);
-        expect(result).to.eq(t.amount);
-      })
-    );
+    for (const t of tests) {
+      await collateral.mock.decimals.returns(t.decimals);
+      const {obligation} = await deployPair(
+        optionFactory,
+        expiryTime,
+        windowSize,
+        t.strike,
+        collateral.address,
+        constants.AddressZero,
+        alice
+      );
+      const result = await obligation.calculateAmountIn(t.satoshis);
+      expect(result).to.eq(t.amount);
+    }
   });
 
   it('should validate amountOut', async () => {
@@ -130,21 +128,19 @@ describe('Conversion for number of obligation and option tokens with number of s
       }
     ];
 
-    await Promise.all(
-      tests.map(async (t) => {
-        await collateral.mock.decimals.returns(t.decimals);
-        const {obligation} = await deployPair(
-          optionFactory,
-          expiryTime,
-          windowSize,
-          t.strike,
-          collateral.address,
-          constants.AddressZero,
-          alice
-        );
-        const output = await obligation.calculateAmountOut(t.amount);
-        expect(output).to.eq(t.satoshis);
-      })
-    );
+    for (const t of tests) {
+      await collateral.mock.decimals.returns(t.decimals);
+      const {obligation} = await deployPair(
+        optionFactory,
+        expiryTime,
+        windowSize,
+        t.strike,
+        collateral.address,
+        constants.AddressZero,
+        alice
+      );
+      const output = await obligation.calculateAmountOut(t.amount);
+      expect(output).to.eq(t.satoshis);
+    }
   });
 });

--- a/test/contracts/token-conversion.test.ts
+++ b/test/contracts/token-conversion.test.ts
@@ -1,13 +1,14 @@
 import chai from 'chai';
 import {ethers} from '@nomiclabs/buidler';
 import {Signer, constants} from 'ethers';
-import {deploy0} from '../../lib/contracts';
+import {deploy1} from '../../lib/contracts';
 import {OptionPairFactoryFactory} from '../../typechain/OptionPairFactoryFactory';
 import {BigNumber, BigNumberish} from 'ethers';
 import {OptionPairFactory} from '../../typechain/OptionPairFactory';
-import {MockCollateralFactory} from '../../typechain';
-import {MockCollateral} from '../../typechain/MockCollateral';
 import {getTimeNow, deployPair} from '../common';
+import {MockContract, deployMockContract} from 'ethereum-waffle';
+import IUniswapV2FactoryArtifact from '../../artifacts/IUniswapV2Factory.json';
+import IERC20Artifact from '../../artifacts/IERC20.json';
 
 const {expect} = chai;
 
@@ -15,21 +16,31 @@ type args = {
   strike: BigNumberish;
   amount: BigNumberish;
   satoshis: BigNumberish;
+  decimals: number;
 };
 
 describe('Conversion for number of obligation and option tokens with number of satoshis', () => {
   let alice: Signer;
 
   let optionFactory: OptionPairFactory;
-  let collateral: MockCollateral;
+  let uniswapFactory: MockContract;
+  let collateral: MockContract;
 
   const expiryTime = getTimeNow() + 1000;
   const windowSize = 1000;
 
   beforeEach('should deploy option factory', async () => {
     [alice] = await ethers.getSigners();
-    optionFactory = await deploy0(alice, OptionPairFactoryFactory);
-    collateral = await deploy0(alice, MockCollateralFactory);
+    uniswapFactory = await deployMockContract(
+      alice,
+      IUniswapV2FactoryArtifact.abi
+    );
+    optionFactory = await deploy1(
+      alice,
+      OptionPairFactoryFactory,
+      uniswapFactory.address
+    );
+    collateral = await deployMockContract(alice, IERC20Artifact.abi);
   });
 
   it('should validate amountIn', async () => {
@@ -39,43 +50,50 @@ describe('Conversion for number of obligation and option tokens with number of s
         // 18 decimals (e.g. Dai, USDC)
         strike: '9000000000000000000000',
         amount: '4500000000000000000000',
-        satoshis: '5000000000'
+        satoshis: '5000000000',
+        decimals: 18
       },
       {
         // 6 decimals (e.g. USDT)
         strike: '9000000000',
         amount: '4500000000',
-        satoshis: '5000000000'
+        satoshis: '5000000000',
+        decimals: 6
       },
       {
         // 0 decimals
         strike: '9000',
         amount: '4500',
-        satoshis: '5000000000'
+        satoshis: '5000000000',
+        decimals: 0
       },
       // 10000 strike, 0.25 BTC
       {
         // 18 decimals (e.g. Dai, USDC)
         strike: '10000000000000000000000',
         amount: '2500000000000000000000',
-        satoshis: '2500000000'
+        satoshis: '2500000000',
+        decimals: 18
       },
       {
         // 6 decimals (e.g. USDT)
         strike: '10000000000',
         amount: '2500000000',
-        satoshis: '2500000000'
+        satoshis: '2500000000',
+        decimals: 6
       },
       {
         // 0 decimals
         strike: '10000',
         amount: '2500',
-        satoshis: '2500000000'
+        satoshis: '2500000000',
+        decimals: 6
       }
     ];
 
     await Promise.all(
       tests.map(async (t) => {
+        await collateral.mock.decimals.returns(t.decimals);
         const {obligation} = await deployPair(
           optionFactory,
           expiryTime,
@@ -96,22 +114,26 @@ describe('Conversion for number of obligation and option tokens with number of s
       {
         strike: '9000000000000000000000',
         amount: '4500000000000000000000',
-        satoshis: 0.5 * Math.pow(10, 10)
+        satoshis: 0.5 * Math.pow(10, 10),
+        decimals: 18
       },
       {
         strike: '9000000000',
         amount: '4500000000',
-        satoshis: 0.5 * Math.pow(10, 10)
+        satoshis: 0.5 * Math.pow(10, 10),
+        decimals: 6
       },
       {
         strike: BigNumber.from(2390).mul(BigNumber.from(10).pow(18)),
         amount: '1199999999978000000000',
-        satoshis: '5020920502'
+        satoshis: '5020920502',
+        decimals: 18
       }
     ];
 
     await Promise.all(
       tests.map(async (t) => {
+        await collateral.mock.decimals.returns(t.decimals);
         const {obligation} = await deployPair(
           optionFactory,
           expiryTime,

--- a/test/contracts/treasury.test.ts
+++ b/test/contracts/treasury.test.ts
@@ -1,12 +1,15 @@
 import chai from 'chai';
 import {Treasury} from '../../typechain/Treasury';
 import {ethers} from '@nomiclabs/buidler';
-import {Signer} from 'ethers';
-import {deploy1} from '../../lib/contracts';
+import {Signer, constants} from 'ethers';
+import {deploy2, reconnect} from '../../lib/contracts';
 import {TreasuryFactory} from '../../typechain/TreasuryFactory';
 import ERC20Artifact from '../../artifacts/ERC20.json';
-
-import {MockContract, deployMockContract} from 'ethereum-waffle';
+import ObligationArtifact from '../../artifacts/Obligation.json';
+import * as bitcoin from 'bitcoinjs-lib';
+import {MockContract, deployMockContract} from '@gregdhill/mock-contract';
+import {ErrorCode, Script} from '../../lib/constants';
+import {getTimeNow} from '../common';
 
 const {expect} = chai;
 
@@ -18,32 +21,171 @@ describe('Treasury.sol', () => {
   let bobAddress: string;
 
   let collateral: MockContract;
+  let obligation: MockContract;
   let treasury: Treasury;
 
-  it('should deploy treasury', async () => {
+  beforeEach('should deploy treasury', async () => {
     [alice, bob] = await ethers.getSigners();
     [aliceAddress, bobAddress] = await Promise.all([
       alice.getAddress(),
       bob.getAddress()
     ]);
-    collateral = await deployMockContract(alice, ERC20Artifact.abi);
-    treasury = await deploy1(alice, TreasuryFactory, collateral.address);
+    [collateral, obligation] = await Promise.all([
+      deployMockContract(alice, ERC20Artifact.abi),
+      deployMockContract(alice, ObligationArtifact.abi)
+    ]);
+    treasury = await deploy2(
+      alice,
+      TreasuryFactory,
+      collateral.address,
+      aliceAddress
+    );
+    await treasury.authorize(obligation.address);
+  });
+
+  it('should fail to deposit funds if position is not set', async () => {
+    await collateral.mock.balanceOf.returns(200);
+    const result = treasury.deposit(aliceAddress);
+    await expect(result).to.be.revertedWith(ErrorCode.ERR_POSITION_NOT_SET);
+  });
+
+  const makeKeyPair = () => {
+    const pair = bitcoin.ECPair.makeRandom();
+    const p2pkh = bitcoin.payments.p2pkh({pubkey: pair.publicKey});
+    return p2pkh;
+  };
+
+  const deposit = async (
+    balance: number,
+    now: number,
+    positionWindow: number,
+    optionWindow: number,
+    strikePrice: number
+  ) => {
+    await reconnect(treasury, TreasuryFactory, alice).position(
+      0,
+      constants.MaxUint256,
+      now + positionWindow,
+      makeKeyPair().hash!,
+      Script.p2pkh
+    );
+
+    await collateral.mock.balanceOf.returns(balance);
+    await treasury.deposit(aliceAddress);
+    await obligation.mock.getDetails.returns(
+      now,
+      optionWindow,
+      strikePrice,
+      0,
+      collateral.address,
+      constants.AddressZero
+    );
+    await obligation.call(
+      treasury,
+      'lock(address,uint256)',
+      aliceAddress,
+      balance
+    );
+    const lockedBalance = await treasury.lockedIn(
+      obligation.address,
+      aliceAddress
+    );
+    expect(lockedBalance.toNumber()).to.eq(balance);
+  };
+
+  it('should not set invalid position', async () => {
+    const result = reconnect(treasury, TreasuryFactory, alice).position(
+      0,
+      constants.MaxUint256,
+      0,
+      makeKeyPair().hash!,
+      Script.p2pkh
+    );
+    await expect(result).to.be.revertedWith(
+      ErrorCode.ERR_POSITION_INVALID_EXPIRY
+    );
+  });
+
+  it('should not deposit without position', async () => {
+    const aliceBalance = 200;
+    await collateral.mock.balanceOf.returns(aliceBalance);
+    const result = treasury.deposit(aliceAddress);
+    await expect(result).to.be.revertedWith(ErrorCode.ERR_POSITION_NOT_SET);
   });
 
   it('should deposit all unreserved funds', async () => {
-    await collateral.mock.balanceOf.returns(200);
-    await treasury.deposit(aliceAddress, aliceAddress);
-    await treasury.lock(aliceAddress, 200);
-    const lockedBalance = await treasury.balanceOf(aliceAddress, aliceAddress);
-    expect(lockedBalance.toNumber()).to.eq(200);
+    const aliceBalance = 200;
+    const now = getTimeNow();
+    const positionWindow = 1000;
+    const optionWindow = 100;
+    const strikePrice = 50;
+
+    await deposit(aliceBalance, now, positionWindow, optionWindow, strikePrice);
+  });
+
+  it('should not unlock reserved funds before expiry', async () => {
+    const aliceBalance = 340;
+    const now = getTimeNow();
+    const positionWindow = 1000;
+    const optionWindow = 100;
+    const strikePrice = 18;
+
+    await deposit(aliceBalance, now, positionWindow, optionWindow, strikePrice);
+
+    await obligation.mock.canExit.returns(false);
+    const result = treasury.unlock(
+      obligation.address,
+      aliceAddress,
+      aliceBalance
+    );
+    await expect(result).to.be.revertedWith(ErrorCode.ERR_MARKET_NOT_EXPIRED);
+  });
+
+  it('should unlock all reserved funds after expiry', async () => {
+    const aliceBalance = 340;
+    const now = getTimeNow();
+    const positionWindow = 1000;
+    const optionWindow = 100;
+    const strikePrice = 18;
+
+    await deposit(aliceBalance, now, positionWindow, optionWindow, strikePrice);
+
+    await obligation.mock.canExit.returns(true);
+    // anyone can unlock funds as long as option has expired
+    await treasury.unlock(obligation.address, aliceAddress, aliceBalance);
+
+    const lockedBalanceAfter = await treasury.lockedIn(
+      obligation.address,
+      aliceAddress
+    );
+    expect(lockedBalanceAfter.toNumber()).to.eq(0);
   });
 
   it('should release funds from market', async () => {
-    await collateral.mock.transfer.returns(true);
-    await collateral.mock.balanceOf.returns(100);
-    await treasury.release(aliceAddress, bobAddress, 100);
+    const aliceBalance = 5236;
+    const now = getTimeNow();
+    const positionWindow = 567;
+    const optionWindow = 400;
+    const strikePrice = 87;
 
-    const lockedBalance = await treasury.balanceOf(aliceAddress, aliceAddress);
-    expect(lockedBalance.toNumber()).to.eq(100);
+    await deposit(aliceBalance, now, positionWindow, optionWindow, strikePrice);
+
+    await collateral.mock.transfer.returns(true);
+    await obligation.call(
+      treasury,
+      'release(address,address,uint256)',
+      aliceAddress,
+      bobAddress,
+      aliceBalance
+    );
+
+    const lockedBalance = await treasury.lockedIn(
+      obligation.address,
+      aliceAddress
+    );
+    expect(lockedBalance.toNumber()).to.eq(0);
   });
 });
+
+// TODO: test position expired
+// TODO: test invalid unlock (params)

--- a/test/integration/options.test.ts
+++ b/test/integration/options.test.ts
@@ -3,13 +3,18 @@ import {Signer, Wallet, constants} from 'ethers';
 import chai from 'chai';
 import {solidity, deployMockContract, MockContract} from 'ethereum-waffle';
 import {MockCollateralFactory} from '../../typechain/MockCollateralFactory';
-import {OptionFactory} from '../../typechain/OptionFactory';
 import {OptionPairFactoryFactory} from '../../typechain/OptionPairFactoryFactory';
 import {ErrorCode, Script} from '../../lib/constants';
 import {MockCollateral} from '../../typechain/MockCollateral';
 import {OptionLibFactory} from '../../typechain/OptionLibFactory';
 import {OptionLib} from '../../typechain/OptionLib';
-import {deploy0, reconnect, getRequestEvent} from '../../lib/contracts';
+import {
+  deploy0,
+  reconnect,
+  getRequestEvent,
+  deploy2,
+  deploy1
+} from '../../lib/contracts';
 import {Option} from '../../typechain/Option';
 import {OptionPairFactory} from '../../typechain/OptionPairFactory';
 import {ObligationFactory} from '../../typechain/ObligationFactory';
@@ -19,14 +24,12 @@ import {Ierc20Factory} from '../../typechain/Ierc20Factory';
 import {Obligation} from '../../typechain/Obligation';
 import {IUniswapV2Factory} from '../../typechain/IUniswapV2Factory';
 import BTCRefereeArtifact from '../../artifacts/BTCReferee.json';
-import {
-  getCreate2OptionAddress,
-  getCreate2ObligationAddress
-} from '../../lib/addresses';
 import {evmSnapFastForward} from '../../lib/mock';
 import {BigNumberish} from 'ethers';
 import {deployPair, getTimeNow} from '../common';
 import {newBigNum} from '../../lib/conversion';
+import {Treasury} from '../../typechain/Treasury';
+import {TreasuryFactory} from '../../typechain';
 
 chai.use(solidity);
 const {expect} = chai;
@@ -43,26 +46,25 @@ const btcHash = '0x5587090c3288b46df8cc928c6910a8c1bbea508f';
 
 async function loadContracts(signer: Signer): Promise<Contracts> {
   const account = await signer.getAddress();
-  const uniswapFactory = (await deployUniswapFactory(
-    signer,
-    account
-  )) as IUniswapV2Factory;
-  const optionPairFactory = await deploy0(signer, OptionPairFactoryFactory);
-  const optionLibFactory = new OptionLibFactory(signer);
-  const optionLib = await optionLibFactory.deploy(
-    uniswapFactory.address,
-    constants.AddressZero
-  );
+  const uniswapFactory = await deployUniswapFactory(signer, account);
+  const [optionFactory, optionLib, collateral, btcReferee] = await Promise.all([
+    deploy1(signer, OptionPairFactoryFactory, uniswapFactory.address),
+    deploy2(
+      signer,
+      OptionLibFactory,
+      uniswapFactory.address,
+      constants.AddressZero
+    ),
+    deploy0(signer, MockCollateralFactory),
+    deployMockContract(signer as Wallet, BTCRefereeArtifact.abi)
+  ]);
 
   return {
-    uniswapFactory: uniswapFactory,
-    collateral: await deploy0(signer, MockCollateralFactory),
-    optionFactory: optionPairFactory,
-    optionLib: optionLib,
-    btcReferee: await deployMockContract(
-      signer as Wallet,
-      BTCRefereeArtifact.abi
-    )
+    uniswapFactory,
+    collateral,
+    optionFactory,
+    optionLib,
+    btcReferee
   };
 }
 
@@ -104,6 +106,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**18]', () => {
 
   let option: Option;
   let obligation: Obligation;
+  let treasury: Treasury;
 
   const expiryTime = getTimeNow() + 1000;
   const windowSize = 1000;
@@ -127,7 +130,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**18]', () => {
       alice.getAddress(),
       bob.getAddress()
     ]);
-    ({option, obligation} = await deployPair(
+    ({option, obligation, treasury} = await deployPair(
       optionFactory,
       expiryTime,
       windowSize,
@@ -152,6 +155,14 @@ describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**18]', () => {
       premiumAmount.add(collateralAmount)
     );
 
+    await reconnect(treasury, TreasuryFactory, alice).position(
+      0,
+      constants.MaxUint256,
+      expiryTime + windowSize,
+      btcHash,
+      Script.p2sh
+    );
+
     await reconnect(optionLib, OptionLibFactory, alice).lockAndWrite(
       obligation.address,
       collateral.address,
@@ -159,9 +170,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**18]', () => {
       collateralAmount,
       premiumAmount,
       0,
-      0,
-      btcHash,
-      Script.p2sh
+      0
     );
 
     const pairAddress = await uniswapFactory.getPair(
@@ -203,7 +212,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**18]', () => {
         obligation,
         ObligationFactory,
         bob
-      ).requestExercise(aliceAddress, amountOutSat.add(1));
+      ).requestExercise(aliceAddress, amountOutSat.add(100));
       await expect(result).to.be.revertedWith(
         ErrorCode.ERR_TRANSFER_EXCEEDS_BALANCE
       );
@@ -261,6 +270,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**6]', () => {
 
   let option: Option;
   let obligation: Obligation;
+  let treasury: Treasury;
 
   const expiryTime = getTimeNow() + 1000;
   const windowSize = 1000;
@@ -284,7 +294,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**6]', () => {
       alice.getAddress(),
       bob.getAddress()
     ]);
-    ({option, obligation} = await deployPair(
+    ({option, obligation, treasury} = await deployPair(
       optionFactory,
       expiryTime,
       windowSize,
@@ -309,6 +319,14 @@ describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**6]', () => {
       premiumAmount.add(collateralAmount)
     );
 
+    await reconnect(treasury, TreasuryFactory, alice).position(
+      0,
+      constants.MaxUint256,
+      expiryTime + windowSize,
+      btcHash,
+      Script.p2sh
+    );
+
     await reconnect(optionLib, OptionLibFactory, alice).lockAndWrite(
       obligation.address,
       collateral.address,
@@ -316,9 +334,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**6]', () => {
       collateralAmount,
       premiumAmount,
       0,
-      0,
-      btcHash,
-      Script.p2sh
+      0
     );
 
     const pairAddress = await uniswapFactory.getPair(
@@ -418,6 +434,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Refund Options [10**18]', () => {
 
   let option: Option;
   let obligation: Obligation;
+  let treasury: Treasury;
 
   const expiryTime = getTimeNow() + 1000;
   const windowSize = 1000;
@@ -440,7 +457,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Refund Options [10**18]', () => {
       alice.getAddress(),
       bob.getAddress()
     ]);
-    ({option, obligation} = await deployPair(
+    ({option, obligation, treasury} = await deployPair(
       optionFactory,
       expiryTime,
       windowSize,
@@ -465,6 +482,14 @@ describe('Put Option (1 Writer, 1 Buyer) - Refund Options [10**18]', () => {
       collateralAmount.add(premiumAmount)
     );
 
+    await reconnect(treasury, TreasuryFactory, alice).position(
+      0,
+      constants.MaxUint256,
+      expiryTime + windowSize,
+      btcHash,
+      Script.p2sh
+    );
+
     await reconnect(optionLib, OptionLibFactory, alice).lockAndWrite(
       obligation.address,
       collateral.address,
@@ -472,9 +497,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Refund Options [10**18]', () => {
       collateralAmount,
       premiumAmount,
       collateralAmount,
-      premiumAmount,
-      btcHash,
-      Script.p2sh
+      premiumAmount
     );
 
     const pairAddress: string = await uniswapFactory.getPair(
@@ -507,11 +530,9 @@ describe('Put Option (1 Writer, 1 Buyer) - Refund Options [10**18]', () => {
     const obligationBalance = await obligation.obligations(aliceAddress);
     expect(obligationBalance).to.eq(collateralAmount);
     await evmSnapFastForward(2000, async () => {
-      await reconnect(obligation, ObligationFactory, alice).refund(
+      await reconnect(treasury, TreasuryFactory, alice).withdraw(
         collateralAmount
       );
-      const obligationBalance = await obligation.obligations(aliceAddress);
-      expect(obligationBalance).to.eq(constants.Zero);
       const collateralBalance = await collateral.balanceOf(aliceAddress);
       expect(collateralBalance).to.eq(collateralAmount);
     });
@@ -534,6 +555,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Transfer Obligations [10**18]', () =>
 
   let option: Option;
   let obligation: Obligation;
+  let treasury: Treasury;
 
   const expiryTime = getTimeNow() + 1000;
   const windowSize = 1000;
@@ -558,7 +580,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Transfer Obligations [10**18]', () =>
       alice.getAddress(),
       eve.getAddress()
     ]);
-    ({option, obligation} = await deployPair(
+    ({option, obligation, treasury} = await deployPair(
       optionFactory,
       expiryTime,
       windowSize,
@@ -583,6 +605,14 @@ describe('Put Option (1 Writer, 1 Buyer) - Transfer Obligations [10**18]', () =>
       collateralAmount.add(premiumAmount)
     );
 
+    await reconnect(treasury, TreasuryFactory, alice).position(
+      0,
+      constants.MaxUint256,
+      expiryTime + windowSize,
+      btcHash,
+      Script.p2sh
+    );
+
     await reconnect(optionLib, OptionLibFactory, alice).lockAndWrite(
       obligation.address,
       collateral.address,
@@ -590,9 +620,7 @@ describe('Put Option (1 Writer, 1 Buyer) - Transfer Obligations [10**18]', () =>
       collateralAmount,
       premiumAmount,
       collateralAmount,
-      premiumAmount,
-      btcHash,
-      Script.p2sh
+      premiumAmount
     );
 
     const obligationBalance = await obligation.balanceOf(aliceAddress);
@@ -664,10 +692,14 @@ describe('Put Option (1 Writer, 1 Buyer) - Transfer Obligations [10**18]', () =>
       amountOut
     );
 
-    await reconnect(obligation, ObligationFactory, eve).setBtcAddress(
+    await reconnect(treasury, TreasuryFactory, eve).position(
+      0,
+      constants.MaxUint256,
+      expiryTime + windowSize,
       btcHash,
       Script.p2sh
     );
+
     await reconnect(optionLib, OptionLibFactory, eve).lockAndBuy(
       amountOut,
       amountInMax,
@@ -702,6 +734,7 @@ describe('Put Option (2 Writers, 1 Buyer) - Transfer Obligations [10*18]', () =>
 
   let option: Option;
   let obligation: Obligation;
+  let treasury: Treasury;
 
   const expiryTime = getTimeNow() + 1000;
   const windowSize = 1000;
@@ -727,7 +760,7 @@ describe('Put Option (2 Writers, 1 Buyer) - Transfer Obligations [10*18]', () =>
       bob.getAddress(),
       eve.getAddress()
     ]);
-    ({option, obligation} = await deployPair(
+    ({option, obligation, treasury} = await deployPair(
       optionFactory,
       expiryTime,
       windowSize,
@@ -753,6 +786,14 @@ describe('Put Option (2 Writers, 1 Buyer) - Transfer Obligations [10*18]', () =>
         collateralAmount.add(premiumAmount)
       );
 
+      await reconnect(treasury, TreasuryFactory, signer).position(
+        0,
+        constants.MaxUint256,
+        expiryTime + windowSize,
+        btcHash,
+        Script.p2sh
+      );
+
       await reconnect(optionLib, OptionLibFactory, signer).lockAndWrite(
         obligation.address,
         collateral.address,
@@ -760,9 +801,7 @@ describe('Put Option (2 Writers, 1 Buyer) - Transfer Obligations [10*18]', () =>
         collateralAmount,
         premiumAmount,
         collateralAmount,
-        premiumAmount,
-        btcHash,
-        Script.p2sh
+        premiumAmount
       );
 
       const obligationBalance = await obligation.obligations(address);
@@ -820,10 +859,19 @@ describe('Put Option (2 Writers, 1 Buyer) - Transfer Obligations [10*18]', () =>
       amountInMax.add(amountOut)
     );
 
+    await reconnect(treasury, TreasuryFactory, bob).position(
+      0,
+      constants.MaxUint256,
+      expiryTime + windowSize,
+      btcHash,
+      Script.p2sh
+    );
+
     const pairAddress = await uniswapFactory.getPair(
       collateral.address,
       obligation.address
     );
+
     const input = await estimateInput(
       pairAddress,
       collateral,

--- a/test/integration/position.test.ts
+++ b/test/integration/position.test.ts
@@ -1,0 +1,180 @@
+import {ethers} from '@nomiclabs/buidler';
+import {Signer, Wallet, constants} from 'ethers';
+import chai from 'chai';
+import {solidity, deployMockContract, MockContract} from 'ethereum-waffle';
+import {MockCollateralFactory} from '../../typechain/MockCollateralFactory';
+import {OptionPairFactoryFactory} from '../../typechain/OptionPairFactoryFactory';
+import {Script} from '../../lib/constants';
+import {MockCollateral} from '../../typechain/MockCollateral';
+import {OptionLibFactory} from '../../typechain/OptionLibFactory';
+import {OptionLib} from '../../typechain/OptionLib';
+import {deploy0, reconnect, deploy2, deploy1} from '../../lib/contracts';
+import {Option} from '../../typechain/Option';
+import {OptionPairFactory} from '../../typechain/OptionPairFactory';
+import {deployUniswapFactory} from '../../lib/uniswap';
+import {Obligation} from '../../typechain/Obligation';
+import {IUniswapV2Factory} from '../../typechain/IUniswapV2Factory';
+import BTCRefereeArtifact from '../../artifacts/BTCReferee.json';
+import {evmSnapFastForward} from '../../lib/mock';
+import {deployPair, getTimeNow} from '../common';
+import {newBigNum} from '../../lib/conversion';
+import {Treasury} from '../../typechain/Treasury';
+import {TreasuryFactory} from '../../typechain';
+
+chai.use(solidity);
+const {expect} = chai;
+
+const btcHash = '0x5587090c3288b46df8cc928c6910a8c1bbea508f';
+
+describe('Put Option (1 Writer, 1 Buyer) - Exercise Options [10**18]', () => {
+  let alice: Signer;
+  let bob: Signer;
+  let charlie: Signer;
+
+  let aliceAddress: string;
+  let bobAddress: string;
+  let charlieAddress: string;
+
+  let uniswapFactory: IUniswapV2Factory;
+  let collateral: MockCollateral;
+  let optionFactory: OptionPairFactory;
+  let optionLib: OptionLib;
+  let btcReferee: MockContract;
+
+  let optionA: Option;
+  let optionB: Option;
+
+  let obligationA: Obligation;
+  let obligationB: Obligation;
+
+  let treasury: Treasury;
+
+  const expiryTimeA = getTimeNow() + 1000;
+  const windowSizeA = 1000;
+
+  const expiryTimeB = expiryTimeA + 5000;
+  const windowSizeB = 1000;
+
+  const strikePriceA = newBigNum(9000, 18);
+  const strikePriceB = newBigNum(9000, 18);
+
+  const premiumAmountA = newBigNum(200, 18);
+  const premiumAmountB = newBigNum(1, 18);
+
+  const collateralAmount = newBigNum(9000, 18);
+
+  const amountOut = newBigNum(4500, 18);
+  const amountInMax = newBigNum(5, 18);
+
+  before(async () => {
+    [alice, bob, charlie] = await ethers.getSigners();
+    [aliceAddress, bobAddress, charlieAddress] = await Promise.all([
+      alice.getAddress(),
+      bob.getAddress(),
+      charlie.getAddress()
+    ]);
+    uniswapFactory = await deployUniswapFactory(charlie, charlieAddress);
+    [optionFactory, optionLib, collateral, btcReferee] = await Promise.all([
+      deploy1(charlie, OptionPairFactoryFactory, uniswapFactory.address),
+      deploy2(
+        charlie,
+        OptionLibFactory,
+        uniswapFactory.address,
+        constants.AddressZero
+      ),
+      deploy0(charlie, MockCollateralFactory),
+      deployMockContract(charlie as Wallet, BTCRefereeArtifact.abi)
+    ]);
+
+    ({option: optionA, obligation: obligationA, treasury} = await deployPair(
+      optionFactory,
+      expiryTimeA,
+      windowSizeA,
+      strikePriceA,
+      collateral.address,
+      btcReferee.address,
+      charlie
+    ));
+
+    ({option: optionB, obligation: obligationB} = await deployPair(
+      optionFactory,
+      expiryTimeB,
+      windowSizeB,
+      strikePriceB,
+      collateral.address,
+      btcReferee.address,
+      charlie
+    ));
+  });
+
+  it('should write put options', async () => {
+    await reconnect(collateral, MockCollateralFactory, alice).mint(
+      aliceAddress,
+      premiumAmountA.add(collateralAmount)
+    );
+
+    await reconnect(collateral, MockCollateralFactory, alice).approve(
+      optionLib.address,
+      premiumAmountA.add(collateralAmount)
+    );
+
+    await reconnect(treasury, TreasuryFactory, alice).position(
+      0,
+      constants.MaxUint256,
+      expiryTimeB + windowSizeB + windowSizeB,
+      btcHash,
+      Script.p2sh
+    );
+
+    await reconnect(optionLib, OptionLibFactory, alice).lockAndWrite(
+      obligationA.address,
+      collateral.address,
+      collateral.address,
+      collateralAmount,
+      premiumAmountA,
+      0,
+      0
+    );
+
+    const pairAddress = await uniswapFactory.getPair(
+      collateral.address,
+      optionA.address
+    );
+    const optionBalance = await optionA.balanceOf(pairAddress);
+    expect(optionBalance, 'options should be in pool').to.eq(collateralAmount);
+  });
+
+  it('should re-write collateral', async () => {
+    return evmSnapFastForward(2000, async () => {
+      await reconnect(collateral, MockCollateralFactory, bob).mint(
+        bobAddress,
+        premiumAmountB.add(amountInMax)
+      );
+
+      await reconnect(collateral, MockCollateralFactory, bob).approve(
+        optionLib.address,
+        premiumAmountB.add(amountInMax)
+      );
+
+      await reconnect(optionLib, OptionLibFactory, bob).unlockAndMintAndBuy(
+        obligationA.address,
+        obligationB.address,
+        collateral.address,
+        aliceAddress,
+        collateralAmount,
+        premiumAmountB,
+        0,
+        0,
+        amountOut,
+        amountInMax
+      );
+
+      const pairAddress = await uniswapFactory.getPair(
+        collateral.address,
+        optionB.address
+      );
+      const optionBalance = await optionB.balanceOf(pairAddress);
+      expect(optionBalance).to.eq(amountOut);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,6 +417,14 @@
     "@ethersproject/properties" "^5.0.0"
     "@ethersproject/strings" "^5.0.0"
 
+"@gregdhill/mock-contract@3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@gregdhill/mock-contract/-/mock-contract-3.0.4.tgz#9e9db93aab26d583f9e21fd9abc13bbbcc396505"
+  integrity sha512-beT5F88pQQtOvgGXdhdMS5vlBcP6lofskWfymnAmXzcMMUrPN82KQGGaAvJe5jjV8Ii739cDaqmS8MAA7Pycog==
+  dependencies:
+    "@ethersproject/abi" "^5.0.1"
+    ethers "^5.0.1"
+
 "@interlay/bitcoin-spv-sol@3.2.2":
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/@interlay/bitcoin-spv-sol/-/bitcoin-spv-sol-3.2.2.tgz#5d4afb571b0c9868799a9ce7c7bc4aee2daaf3d9"
@@ -750,11 +758,6 @@
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.5.2.tgz#4d74670ead39e4f4fdab605a393ba8ea2390a2c4"
   integrity sha512-uRyvnvVYmgNmTBpWDbBsH/0kPESQhQpEc4KsvMRLVzFJ1o1s0uIv0Y6Y9IB5vI1Dwz2CbS4X/y4Wyw/75cTFnQ==
-
-"@solidity-parser/parser@^0.6.0":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.6.2.tgz#49707fc4e06649d39d6b25bdab2e9093d372ce50"
-  integrity sha512-kUVUvrqttndeprLoXjI5arWHeiP3uh4XODAKbG+ZaWHCVQeelxCbnXBeWxZ2BPHdXgH0xR9dU1b916JhDhbgAA==
 
 "@solidity-parser/parser@^0.7.0":
   version "0.7.0"
@@ -8741,11 +8744,11 @@ solhint-plugin-prettier@^0.0.4:
     prettier-linter-helpers "^1.0.0"
 
 solhint@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.1.0.tgz#50d58c9af921a01350164350144a9809d5ec2975"
-  integrity sha512-Cc0wqKzg0NviDF7H5zsrGJ/hVwwkGqi0Hkc3YtedTev4alkJv4YADdJg4y586MpfEvMX4QPp7LugsmJzoeChkQ==
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/solhint/-/solhint-3.2.0.tgz#e3b3e568f64f71328f410a97f06e802033f0d7d2"
+  integrity sha512-BGp7JnnoLzknGC/arcH33oN/LjOz0hKgdauOcBOO5jNjhjnPQ3cAacSMH64fWYShAg5+HYQaSRubInpSKSvzLg==
   dependencies:
-    "@solidity-parser/parser" "^0.6.0"
+    "@solidity-parser/parser" "^0.7.0"
     ajv "^6.6.1"
     antlr4 "4.7.1"
     ast-parents "0.0.1"


### PR DESCRIPTION
Signed-off-by: Gregory Hill <gregorydhill@outlook.com>

The previous setup requires that a writer routinely re-invests their collateral once the associated option pair has expired. This is a problem in practice as gas (transaction execution) fees are currently very high on mainnet. Instead, we should allow the writer to set their 'position' and allow collateral re-use (thereby accruing premium) subject to the constraints defined (i.e. expiry, min & max strike).

The approach implemented in this PR allows a third party to reuse previously bought backing collateral by cross-validating expiry dates and strike prices via the treasury module. In this additional step (`unlockAndMintAndBuy`) we ask the treasury to unlock an amount of collateral and use it to write new option tokens to the associated Uniswap pool. However, it is possible to redistribute the writer's collateral across many option pools which can be a problem when Alice wants to redeem this. One proposed solution is to use the Balancer AMM which would allow us to configure a higher premium.

Since the treasury now checks the expiry of a particular market we need to call the treasury from the mocks in the unit tests. This is a currently unreleased feature of `waffle-mock-contract` so I have temporarily published a fork which we can use until a new version is published upstream.