### PR TITLE
fix: avoid issue when recompiling typescript

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,8 +1,7 @@
-import {USDT} from './lib/constants';
-
 // Plugins
 import '@nomiclabs/hardhat-ganache';
 import '@nomiclabs/hardhat-waffle';
+import '@nomiclabs/hardhat-ethers';
 import 'hardhat-typechain';
 import 'hardhat-gas-reporter';
 

--- a/index.ts
+++ b/index.ts
@@ -7,4 +7,4 @@ export {
   ReadWriteContracts,
   ReadWriteOptionPair
 } from './lib/contracts';
-export {XOpts} from './lib/xopts';
+export {XOpts, createXOpts} from './lib/xopts';

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "hardhat": "hardhat node",
     "ganache": "hardhat run scripts/ganache.ts",
     "tsc": "tsc && cp typechain/*.d.ts dist/typechain/",
+    "watch::tsc": "tsc -w",
     "clean": "rm -rf artifacts cache typechain dist",
     "docs": "solidity-docgen --solc-module=./node_modules/solc -t docs -o docs/contracts",
     "lint::typescript": "eslint './**/*.ts' --ext .ts",
@@ -89,7 +90,7 @@
     "ts-generator": "0.0.8",
     "ts-node": "^8.9.0",
     "typechain": "2.0.0",
-    "typescript": "^3.8.3"
+    "typescript": "^4.0.5"
   },
   "dependencies": {
     "bitcoinjs-lib": "^5.1.10",

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -26,7 +26,7 @@ async function main(): Promise<void> {
 
   const collateral = await deploy0(signers[0], MockCollateralFactory);
   await collateral.mint(await signers[0].getAddress(), newBigNum(100_000, 18));
-  const optionFactory = await deploy0(signers[0], OptionPairFactoryFactory);
+  const optionFactory = await deploy1(signers[0], OptionPairFactoryFactory, '');
   // TODO: make conditional
   const uniswapFactory = await deployUniswapFactory(signers[0], account);
   const optionLib = await deploy2(

--- a/scripts/metrics.ts
+++ b/scripts/metrics.ts
@@ -5,7 +5,7 @@ import {newBigNum} from '../lib/conversion';
 import {MockCollateralFactory} from '../typechain/MockCollateralFactory';
 import {Script} from '../lib/constants';
 import * as bitcoin from 'bitcoinjs-lib';
-import {deploy0, reconnect} from '../lib/contracts';
+import {deploy0, deploy1, reconnect} from '../lib/contracts';
 import {MockBtcRefereeFactory} from '../typechain/MockBtcRefereeFactory';
 import {OptionPairFactoryFactory} from '../typechain/OptionPairFactoryFactory';
 import {OptionFactory} from '../typechain/OptionFactory';
@@ -25,7 +25,7 @@ async function main(): Promise<void> {
   const collateral = await deploy0(alice, MockCollateralFactory);
   const referee = await deploy0(alice, MockBtcRefereeFactory);
 
-  const contract = await deploy0(alice, OptionPairFactoryFactory);
+  const contract = await deploy1(alice, OptionPairFactoryFactory, '');
 
   let receipt = await contract.deployTransaction.wait(0);
   console.log(`Gas [Deploy]: ${receipt.gasUsed?.toString()}`);

--- a/scripts/testdata.ts
+++ b/scripts/testdata.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import {ethers} from '@nomiclabs/buidler';
+import {ethers} from 'hardhat';
 import {MockCollateralFactory} from '../typechain/MockCollateralFactory';
 import {Signer, constants} from 'ethers';
 import * as bitcoin from 'bitcoinjs-lib';
@@ -96,7 +96,7 @@ async function main(): Promise<void> {
 
   const collateral = await deploy0(signers[0], MockCollateralFactory);
   await collateral.mint(await signers[0].getAddress(), newBigNum(100_000, 18));
-  const optionFactory = await deploy0(signers[0], OptionPairFactoryFactory);
+  const optionFactory = await deploy1(signers[0], OptionPairFactoryFactory, '');
   // TODO: make conditional
   const uniswapFactory = await deployUniswapFactory(alice, aliceAddress);
   const optionLib = await deploy2(

--- a/test/lib/mock/xopts.test.ts
+++ b/test/lib/mock/xopts.test.ts
@@ -1,10 +1,9 @@
 import {expect} from 'chai';
-import {MockProvider} from 'ethereum-waffle';
 import {providers, Signer, VoidSigner} from 'ethers';
-import {Deployments, XOpts} from '../../..';
+import {Deployments} from '../../../lib/addresses';
 import mockDb from '../../../lib/mock/db.json';
 import {MockXOpts} from '../../../lib/mock/xopts';
-import {createXOpts} from '../../../lib/xopts';
+import {createXOpts, XOpts} from '../../../lib/xopts';
 
 describe('MockXOpts', () => {
   describe('unit', () => {

--- a/test/lib/monetary.test.ts
+++ b/test/lib/monetary.test.ts
@@ -193,16 +193,17 @@ describe('MonetaryAmount', () => {
   type toBTCAmount = 'toSatoshi' | 'toMSatoshi' | 'toBTC';
 
   describe('BTCAmount', () => {
-    const cases: [
-      (amount: BigSource) => monetary.BTCAmount,
-      toBTCAmount,
-      number
-    ][] = [
-      [monetary.BTCAmount.fromSatoshi, 'toSatoshi', 100_000_000],
-      [monetary.BTCAmount.fromMSatoshi, 'toMSatoshi', 100_000],
-      [monetary.BTCAmount.fromBTC, 'toBTC', 1]
+    const Amount = monetary.BTCAmount;
+    const cases: {
+      from: (amount: BigSource) => monetary.BTCAmount;
+      toName: toBTCAmount;
+      decimalMul: number;
+    }[] = [
+      {from: Amount.fromSatoshi, toName: 'toSatoshi', decimalMul: 100_000_000},
+      {from: Amount.fromMSatoshi, toName: 'toMSatoshi', decimalMul: 100_000},
+      {from: monetary.BTCAmount.fromBTC, toName: 'toBTC', decimalMul: 1}
     ];
-    cases.forEach(([from, toName, decimalMul]) => {
+    cases.forEach(({from, toName, decimalMul}) => {
       describe(from.name, () => {
         it('should be symmetric with toSatoshi', () => {
           fc.assert(
@@ -237,16 +238,17 @@ describe('MonetaryAmount', () => {
   type toETHAmount = 'toWei' | 'toGWei' | 'toEther';
 
   describe('ETHAmount', () => {
-    const cases: [
-      (amount: BigSource) => monetary.ETHAmount,
-      toETHAmount,
-      number
-    ][] = [
-      [monetary.ETHAmount.fromWei, 'toWei', Math.pow(10, 18)],
-      [monetary.ETHAmount.fromGWei, 'toGWei', Math.pow(10, 9)],
-      [monetary.ETHAmount.fromEther, 'toEther', 1]
+    const Amount = monetary.ETHAmount;
+    const cases: {
+      from: (amount: BigSource) => monetary.ETHAmount;
+      toName: toETHAmount;
+      decimalMul: number;
+    }[] = [
+      {from: Amount.fromWei, toName: 'toWei', decimalMul: Math.pow(10, 18)},
+      {from: Amount.fromGWei, toName: 'toGWei', decimalMul: Math.pow(10, 9)},
+      {from: Amount.fromEther, toName: 'toEther', decimalMul: 1}
     ];
-    cases.forEach(([from, toName, decimalMul]) => {
+    cases.forEach(({from, toName, decimalMul}) => {
       describe(from.name, () => {
         it('should be symmetric with toWei', () => {
           fc.assert(

--- a/yarn.lock
+++ b/yarn.lock
@@ -3908,15 +3908,7 @@ ethereumjs-abi@0.6.7:
     bn.js "^4.11.8"
     ethereumjs-util "^6.0.0"
 
-ethereumjs-abi@^0.6.8:
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/ethereumjs-abi/-/ethereumjs-abi-0.6.8.tgz#71bc152db099f70e62f108b7cdfca1b362c6fcae"
-  integrity sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==
-  dependencies:
-    bn.js "^4.11.8"
-    ethereumjs-util "^6.0.0"
-
-"ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
+ethereumjs-abi@^0.6.8, "ethereumjs-abi@git+https://github.com/ethereumjs/ethereumjs-abi.git":
   version "0.6.8"
   resolved "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b"
   dependencies:
@@ -9429,10 +9421,10 @@ typeforce@^1.11.3, typeforce@^1.11.5:
   resolved "https://registry.yarnpkg.com/typeforce/-/typeforce-1.18.0.tgz#d7416a2c5845e085034d70fcc5b6cc4a90edbfdc"
   integrity sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==
 
-typescript@^3.8.3:
-  version "3.9.7"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
-  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+typescript@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 typewise-core@^1.2, typewise-core@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
@theodorebugnet Sorry about the file overwriting error nonsense, it was because of this line: https://github.com/interlay/xopts/compare/daniel/fix-compilation?expand=1#diff-38a9ff0c392fac469c82e567839d722dca659eeab6da5ce333eba8be6cbaaa4bL4 which made `dist` part of the source.
I fixed a couple of other errors and upgraded TypeScript while I was at it.